### PR TITLE
Add interactive Look Tuning panel with live sliders and copyable JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,109 @@
           </label>
         </div>
 
+        <div class="lookPanel collapsed" id="lookPanel">
+          <button
+            id="lookToggleBtn"
+            class="panelToggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="lookControls"
+          >
+            <span>🎨 Look Tuning</span>
+            <span class="panelChevron" aria-hidden="true">▾</span>
+          </button>
+          <div id="lookControls" class="lookControls" aria-hidden="true">
+            <div class="sliderRow">
+              <label for="lookExposure">toneMappingExposure</label>
+              <input
+                type="range"
+                id="lookExposure"
+                min="0.6"
+                max="1.8"
+                step="0.01"
+                data-look-control="toneMappingExposure"
+              />
+              <span class="sliderValue" data-look-value="toneMappingExposure"></span>
+            </div>
+            <div class="sliderRow">
+              <label for="lookHemi">hemiIntensity</label>
+              <input
+                type="range"
+                id="lookHemi"
+                min="0"
+                max="1"
+                step="0.01"
+                data-look-control="hemiIntensity"
+              />
+              <span class="sliderValue" data-look-value="hemiIntensity"></span>
+            </div>
+            <div class="sliderRow">
+              <label for="lookAmbient">ambientIntensity</label>
+              <input
+                type="range"
+                id="lookAmbient"
+                min="0"
+                max="1"
+                step="0.01"
+                data-look-control="ambientIntensity"
+              />
+              <span class="sliderValue" data-look-value="ambientIntensity"></span>
+            </div>
+            <div class="sliderRow">
+              <label for="lookKey">keyLightIntensity</label>
+              <input
+                type="range"
+                id="lookKey"
+                min="0"
+                max="2"
+                step="0.01"
+                data-look-control="keyLightIntensity"
+              />
+              <span class="sliderValue" data-look-value="keyLightIntensity"></span>
+            </div>
+            <div class="sliderRow">
+              <label for="lookRim">rimLightIntensity</label>
+              <input
+                type="range"
+                id="lookRim"
+                min="0"
+                max="2"
+                step="0.01"
+                data-look-control="rimLightIntensity"
+              />
+              <span class="sliderValue" data-look-value="rimLightIntensity"></span>
+            </div>
+            <div class="sliderRow">
+              <label for="lookEnv">envIntensityMultiplier</label>
+              <input
+                type="range"
+                id="lookEnv"
+                min="0"
+                max="3"
+                step="0.05"
+                data-look-control="envIntensityMultiplier"
+              />
+              <span class="sliderValue" data-look-value="envIntensityMultiplier"></span>
+            </div>
+            <div class="sliderRow">
+              <label for="lookEmissive">emissiveIntensityMultiplier</label>
+              <input
+                type="range"
+                id="lookEmissive"
+                min="0"
+                max="4"
+                step="0.05"
+                data-look-control="emissiveIntensityMultiplier"
+              />
+              <span class="sliderValue" data-look-value="emissiveIntensityMultiplier"></span>
+            </div>
+            <div class="lookActions">
+              <button id="copyLookBtn" class="btn">📋 Copy Current Look</button>
+              <span class="hintText">Press <kbd>P</kbd> to print JSON.</span>
+            </div>
+          </div>
+        </div>
+
         <div class="row tiny">
           <button id="printTraitsBtn" class="btn">🧩 Trait URLs</button>
           <button id="printRigBtn" class="btn">🛠 Rig Bones</button>

--- a/main.js
+++ b/main.js
@@ -79,7 +79,11 @@ const LOOK_CONTROLS = {
   keyIntensity: 0.75,
   rimIntensity: 0.35,
   envMapIntensity: 1.2,
-  emissiveIntensity: 1.6
+  emissiveIntensity: 1.6,
+  keyLightIntensity: 0.75,
+  rimLightIntensity: 0.35,
+  envIntensityMultiplier: 1.2,
+  emissiveIntensityMultiplier: 1.6
 };
 
 const LOOK_PRESETS = {
@@ -143,6 +147,27 @@ function registerMaterialDefaults(m) {
   }
 }
 
+function normalizeLookControls() {
+  if (LOOK_CONTROLS.keyLightIntensity === undefined) {
+    LOOK_CONTROLS.keyLightIntensity = LOOK_CONTROLS.keyIntensity ?? 0.75;
+  }
+  if (LOOK_CONTROLS.rimLightIntensity === undefined) {
+    LOOK_CONTROLS.rimLightIntensity = LOOK_CONTROLS.rimIntensity ?? 0.35;
+  }
+  if (LOOK_CONTROLS.envIntensityMultiplier === undefined) {
+    LOOK_CONTROLS.envIntensityMultiplier = LOOK_CONTROLS.envMapIntensity ?? 1.0;
+  }
+  if (LOOK_CONTROLS.emissiveIntensityMultiplier === undefined) {
+    LOOK_CONTROLS.emissiveIntensityMultiplier =
+      LOOK_CONTROLS.emissiveIntensity ?? 1.0;
+  }
+
+  LOOK_CONTROLS.keyIntensity = LOOK_CONTROLS.keyLightIntensity;
+  LOOK_CONTROLS.rimIntensity = LOOK_CONTROLS.rimLightIntensity;
+  LOOK_CONTROLS.envMapIntensity = LOOK_CONTROLS.envIntensityMultiplier;
+  LOOK_CONTROLS.emissiveIntensity = LOOK_CONTROLS.emissiveIntensityMultiplier;
+}
+
 function applyLookToMaterials(root) {
   if (!root) return;
   root.traverse((child) => {
@@ -155,13 +180,13 @@ function applyLookToMaterials(root) {
 
       if ("envMapIntensity" in m) {
         m.envMapIntensity =
-          m.userData.baseEnvMapIntensity * LOOK_CONTROLS.envMapIntensity;
+          m.userData.baseEnvMapIntensity * LOOK_CONTROLS.envIntensityMultiplier;
       }
 
       if (m.emissiveMap) {
         m.emissive = new THREE.Color(0xffffff);
         const base = m.userData.baseEmissiveIntensity ?? 1.0;
-        m.emissiveIntensity = base * LOOK_CONTROLS.emissiveIntensity;
+        m.emissiveIntensity = base * LOOK_CONTROLS.emissiveIntensityMultiplier;
       }
 
       m.needsUpdate = true;
@@ -170,13 +195,14 @@ function applyLookToMaterials(root) {
 }
 
 function applyLookControls() {
+  normalizeLookControls();
   renderer.toneMapping = resolveToneMapping(LOOK_CONTROLS.toneMapping);
   renderer.toneMappingExposure = LOOK_CONTROLS.toneMappingExposure;
 
   hemisphereLight.intensity = LOOK_CONTROLS.hemiIntensity;
   ambientLight.intensity = LOOK_CONTROLS.ambientIntensity;
-  keyLight.intensity = LOOK_CONTROLS.keyIntensity;
-  rim.intensity = LOOK_CONTROLS.rimIntensity;
+  keyLight.intensity = LOOK_CONTROLS.keyLightIntensity;
+  rim.intensity = LOOK_CONTROLS.rimLightIntensity;
 
   applyLookToMaterials(avatarGroup);
 }
@@ -185,7 +211,9 @@ function applyLookPreset(name) {
   const preset = LOOK_PRESETS[name];
   if (!preset) return;
   Object.assign(LOOK_CONTROLS, preset);
+  normalizeLookControls();
   applyLookControls();
+  syncLookSliders();
   const msg = `🎨 Look preset applied: ${name}`;
   console.log(msg, { ...LOOK_CONTROLS });
   logLine(msg);
@@ -210,6 +238,10 @@ const el = {
   logPanel: document.getElementById("logPanel"),
   logToggleBtn: document.getElementById("logToggleBtn"),
   logChevron: document.getElementById("logChevron"),
+  lookPanel: document.getElementById("lookPanel"),
+  lookToggleBtn: document.getElementById("lookToggleBtn"),
+  lookControls: document.getElementById("lookControls"),
+  copyLookBtn: document.getElementById("copyLookBtn"),
 
   status: document.getElementById("status"),
   friendsiesId: document.getElementById("friendsiesId"),
@@ -268,6 +300,43 @@ function clearLog() {
   logLine("Transcript cleared.");
 }
 
+function formatLookValue(value) {
+  if (typeof value !== "number" || Number.isNaN(value)) return String(value);
+  return value.toFixed(2);
+}
+
+function syncLookSliders() {
+  const sliders = document.querySelectorAll("[data-look-control]");
+  sliders.forEach((slider) => {
+    const key = slider.dataset.lookControl;
+    if (!key || !(key in LOOK_CONTROLS)) return;
+    const value = LOOK_CONTROLS[key];
+    slider.value = String(value);
+  });
+
+  const valueEls = document.querySelectorAll("[data-look-value]");
+  valueEls.forEach((elValue) => {
+    const key = elValue.dataset.lookValue;
+    if (!key || !(key in LOOK_CONTROLS)) return;
+    elValue.textContent = formatLookValue(LOOK_CONTROLS[key]);
+  });
+}
+
+function updateLookControl(key, value) {
+  LOOK_CONTROLS[key] = value;
+  normalizeLookControls();
+  applyLookControls();
+  syncLookSliders();
+}
+
+function copyCurrentLook() {
+  normalizeLookControls();
+  const json = JSON.stringify(LOOK_CONTROLS, null, 2);
+  logSection("Current Look JSON");
+  logLine(json);
+  console.log("Current Look JSON", json);
+}
+
 // UI visibility
 function getBoolLS(key, fallback = false) {
   const v = localStorage.getItem(key);
@@ -306,6 +375,25 @@ el.logToggleBtn?.addEventListener("click", () => {
 
 el.clearLogBtn?.addEventListener("click", clearLog);
 
+el.lookToggleBtn?.addEventListener("click", () => {
+  if (!el.lookPanel || !el.lookControls) return;
+  const collapsed = !el.lookPanel.classList.contains("collapsed");
+  el.lookPanel.classList.toggle("collapsed", collapsed);
+  el.lookToggleBtn.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  el.lookControls.setAttribute("aria-hidden", collapsed ? "true" : "false");
+});
+
+el.copyLookBtn?.addEventListener("click", copyCurrentLook);
+
+document.querySelectorAll("[data-look-control]").forEach((slider) => {
+  slider.addEventListener("input", (event) => {
+    const key = event.target.dataset.lookControl;
+    const value = Number(event.target.value);
+    if (!key || !Number.isFinite(value)) return;
+    updateLookControl(key, value);
+  });
+});
+
 document.addEventListener("keydown", (e) => {
   const tag = e.target && e.target.tagName ? e.target.tagName.toLowerCase() : "";
   const typing = tag === "input" || tag === "select" || tag === "textarea";
@@ -320,6 +408,7 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "1") applyLookPreset("Cinematic");
   if (e.key === "2") applyLookPreset("Punchy Toybox");
   if (e.key === "3") applyLookPreset("Soft Pastel");
+  if (e.key.toLowerCase() === "p") copyCurrentLook();
 });
 
 // ----------------------------
@@ -431,6 +520,7 @@ avatarGroup.position.y = -2.5;
 scene.add(avatarGroup);
 
 applyLookPreset("Cinematic");
+syncLookSliders();
 
 // ----------------------------
 // State

--- a/style.css
+++ b/style.css
@@ -198,6 +198,76 @@ canvas { display: block; }
   font-size: 12px;
   opacity: 0.65;
 }
+
+/* Look tuning panel */
+.lookPanel {
+  margin-top: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(0,0,0,0.06);
+  background: rgba(255,255,255,0.65);
+  overflow: hidden;
+}
+
+.panelToggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(0,0,0,0.78);
+}
+
+.panelToggle:hover { background: rgba(0,0,0,0.03); }
+
+.panelChevron {
+  transition: transform 140ms ease;
+}
+
+.lookPanel.collapsed .panelChevron {
+  transform: rotate(-90deg);
+}
+
+.lookControls {
+  padding: 10px;
+  border-top: 1px solid rgba(0,0,0,0.06);
+  display: grid;
+  gap: 8px;
+}
+
+.lookPanel.collapsed .lookControls {
+  display: none;
+}
+
+.sliderRow {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 1.6fr minmax(42px, auto);
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.sliderRow input[type="range"] {
+  width: 100%;
+}
+
+.sliderValue {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  opacity: 0.7;
+}
+
+.lookActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
 kbd {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 11px;


### PR DESCRIPTION
### Motivation
- Provide real-time, fine-grained control over the scene "look" so artists can tweak and lock a final appearance without touching presets. 
- Offer a quick way to export the current look as JSON and a keyboard backup to print the look for re-use as a preset.

### Description
- Added a collapsible "Look Tuning" panel with sliders and a copy button to the main controls UI so users can tweak: `toneMappingExposure`, `hemiIntensity`, `ambientIntensity`, `keyLightIntensity`, `rimLightIntensity`, `envIntensityMultiplier`, and `emissiveIntensityMultiplier` (index.html — Look Tuning section).
- Added CSS for the panel, sliders, and actions (style.css — Look tuning panel styles).
- Implemented live wiring in `main.js`: extended `LOOK_CONTROLS` with the new multipliers, added `normalizeLookControls()` to preserve preset compatibility, added `syncLookSliders()` and `updateLookControl()` to apply changes live via existing `applyLookControls()` and `applyLookToMaterials()`, added `copyCurrentLook()` to print JSON to the transcript and console, and added `P` hotkey mapping to print the current look JSON as a backup (main.js — Look controls + UI wiring sections).
- Kept existing `LOOK_CONTROLS` and `LOOK_PRESETS` intact and preserved all Three.js usage, loader, and animation/rigging logic as requested.
- Files changed: `index.html` (Look Tuning UI block under controls), `style.css` (look tuning styles), and `main.js` (control model + UI wiring + hotkey).

### Testing
- Launched a temporary static server and used Playwright to open `index.html`, open the Look Tuning panel, and capture a screenshot to verify the panel and sliders render; the screenshot (`artifacts/look-tuning-panel.png`) was produced successfully. (automated UI smoke test — succeeded)
- No unit tests were added; no other automated test failures were observed during the smoke verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795015d80483238e555811f9cd24e0)