### PR TITLE
Disable depth testing for face overlay material

### DIFF
--- a/main.js
+++ b/main.js
@@ -841,6 +841,7 @@ function createSkinnedFaceOverlayFromHead(headScene, faceTexture) {
     map: faceTexture,
     transparent: true,
     alphaTest: 0.5,
+    depthTest: false,
     depthWrite: false
   });
   faceMat.polygonOffset = true;


### PR DESCRIPTION
### Motivation
- Ensure the face overlay always renders above head geometry so it never appears partially occluded by depth testing.

### Description
- Set `depthTest: false` on the face overlay `MeshStandardMaterial` in `createSkinnedFaceOverlayFromHead` in `main.js`, preserving `depthWrite: false` and the existing `overlay.renderOrder = 999` behavior.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture `artifacts/face-overlay.png`, and the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697975e1b82c832399260b0c5c7e1c19)