### PR TITLE
Ensure avatar world matrices update before face overlay

### DIFF
--- a/main.js
+++ b/main.js
@@ -1065,13 +1065,15 @@ async function loadFriendsies(id) {
 
   bodyRoot = bodyRes.gltf.scene;
   loadedParts.push(bodyRoot);
-  avatarGroup.add(bodyRoot);
 
   bodySkinned = findFirstSkinnedMesh(bodyRoot);
   if (!bodySkinned?.skeleton) return setStatus("body loaded but no skeleton ❌");
 
   bodySkeleton = bodySkinned.skeleton;
   collectRigInfo();
+
+  avatarGroup.add(bodyRoot);
+  avatarGroup.updateMatrixWorld(true);
 
   mixer = new THREE.AnimationMixer(bodyRoot);
 


### PR DESCRIPTION
### Motivation
- The face overlay computation relies on correct world transforms (`faceAnchor.matrixWorld` / `src.matrixWorld`) so the body/head world matrices must be established before creating the overlay.  

### Description
- Move adding `bodyRoot` into `avatarGroup` to occur after `collectRigInfo()` and add `avatarGroup.updateMatrixWorld(true)` so the scene graph has correct world transforms before calling `createSkinnedFaceOverlayFromHead`.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697986a382c48323803889e64cfcf076)