### PR TITLE
Fix face overlay sizing for skinned meshes

### DIFF
--- a/main.js
+++ b/main.js
@@ -883,7 +883,8 @@ function createSkinnedFaceOverlayFromHead(headScene, faceTexture) {
 
     let overlay;
     if (src.isSkinnedMesh) {
-      overlay = new THREE.SkinnedMesh(src.geometry, faceMat);
+      overlay = src.clone();
+      overlay.material = faceMat;
       const bindMatrix = src.bindMatrix ? src.bindMatrix.clone() : new THREE.Matrix4();
       overlay.bind(bodySkeleton, bindMatrix);
       overlay.bindMode = src.bindMode || "attached";

--- a/main.js
+++ b/main.js
@@ -895,14 +895,22 @@ function createSkinnedFaceOverlayFromHead(headScene, faceTexture) {
     overlay.renderOrder = 999;
     overlay.frustumCulled = false;
 
-    const local = new THREE.Matrix4()
-      .copy(faceAnchor.matrixWorld)
-      .invert()
-      .multiply(src.matrixWorld);
+    let parentForOverlay = faceAnchor;
+    if (src.isSkinnedMesh) {
+      parentForOverlay = src.parent || faceAnchor;
+      overlay.position.copy(src.position);
+      overlay.quaternion.copy(src.quaternion);
+      overlay.scale.copy(src.scale);
+    } else {
+      const local = new THREE.Matrix4()
+        .copy(faceAnchor.matrixWorld)
+        .invert()
+        .multiply(src.matrixWorld);
 
-    local.decompose(overlay.position, overlay.quaternion, overlay.scale);
+      local.decompose(overlay.position, overlay.quaternion, overlay.scale);
+    }
 
-    faceAnchor.add(overlay);
+    parentForOverlay.add(overlay);
     faceOverlayMeshes.push(overlay);
     made++;
   }


### PR DESCRIPTION
### Motivation
- Face overlays were rendering extremely small because skinned overlay meshes were receiving double / wrong transforms when anchored to the head bone and also re-computed relative to the face anchor.
- The intent is to preserve the original transform of each skinned source mesh so the face texture overlay matches the source geometry scale and position.

### Description
- Update `createSkinnedFaceOverlayFromHead` in `main.js` to parent skinned overlays alongside their source mesh by using `src.parent` and copying `position`, `quaternion`, and `scale` from `src` instead of re-computing via the `faceAnchor` matrix.
- Preserve existing behavior for non-skinned (rigid) meshes by computing the overlay transform relative to the `faceAnchor` as before.
- The change avoids double-transforms for skinned meshes and keeps rigid overlays anchored to the avatar head bone for consistent placement.

### Testing
- Attempted an automated visual verification by starting a local server with `python -m http.server 8000` and running a Playwright screenshot script, but the Playwright browser failed to launch (SIGSEGV), so no screenshot confirmation was produced.
- No other automated tests were run; change is a visual/transform fix and should be validated in a browser with representative GLB/texture assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979913c0ad083238402c5f52b4e768c)