### PR TITLE
Add clipboard copy for look tuning JSON

### DIFF
--- a/main.js
+++ b/main.js
@@ -414,11 +414,51 @@ function updateLookControl(key, value) {
   syncLookSliders();
 }
 
-function copyCurrentLook() {
+async function copyTextToClipboard(text) {
+  if (!text) return false;
+
+  if (navigator?.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+
+  document.body.removeChild(textarea);
+  return copied;
+}
+
+async function copyCurrentLook() {
   const json = JSON.stringify(getCanonicalLookSnapshot(), null, 2);
   logSection("Current Look JSON");
   logLine(json);
   console.log("Current Look JSON", json);
+
+  const copied = await copyTextToClipboard(json);
+  if (copied) {
+    setStatus("Look JSON copied to clipboard ✅");
+    logLine("📋 Look JSON copied to clipboard.");
+  } else {
+    setStatus("Clipboard copy failed ⚠️");
+    logLine("Clipboard copy failed. Copy from transcript instead.", "warn");
+  }
 }
 
 // UI visibility


### PR DESCRIPTION
### Motivation
- Provide an easy way to copy the current "Look" configuration JSON so users can copy/share/apply look presets quickly and get immediate success/failure feedback.

### Description
- Added an async `copyTextToClipboard` helper with a `navigator.clipboard` path and a fallback using a hidden `<textarea>` + `document.execCommand('copy')`, and updated `copyCurrentLook` to call it and report success/failure via `setStatus` and `logLine`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698236156050832396b64c309bcd851c)