### PR TITLE
Default carousel to full token range and decouple wallet lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,15 +322,15 @@
 
             <div class="row">
               <div class="pill wide">
-                <span class="pillLabel">Your Friendsies</span>
+                <span class="pillLabel">Wallet-owned Friendsies</span>
                 <select id="walletTokensSelect" disabled>
-                  <option value="">(lookup a wallet)</option>
+                  <option value="">(wallet lookup optional)</option>
                 </select>
               </div>
 
-              <button id="walletLoadSelectedBtn" class="btn">Load Selected</button>
+              <button id="walletLoadSelectedBtn" class="btn">Load Highlighted</button>
 
-              <span class="hintText" id="walletHint">Tip: lookup → pick token → Load Selected</span>
+              <span class="hintText" id="walletHint">Tip: browse #1–#10000 in the carousel; wallet lookup is optional for owned-token overlays.</span>
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation
- Make the token carousel usable at app boot without requiring a wallet lookup by defaulting the carousel to the full `1..10000` range. 
- Treat wallet-derived token lists as an optional overlay/mode rather than the primary source for carousel visibility and behavior. 
- Remove UI copy that assumes wallet-first flows so the app is clearer when no wallet is provided.

### Description
- Initialize carousel state with `DEFAULT_CAROUSEL_TOKEN_IDS = Array.from({ length: 10000 }, (_, i) => i + 1)` and default the runtime to `carouselMode === CAROUSEL_MODES.defaultRange`. (changes in `main.js`)
- Add mode scaffolding: `CAROUSEL_MODES` plus `walletOwnedTokenIds`, `getCarouselTokenIdsForMode()` and `setCarouselMode()` so wallet results can be treated as an optional overlay (`defaultRange` | `walletOwned`). (changes in `main.js`)
- Decouple visibility from wallet lookup by making `setCarouselVisible()` mode-aware and rendering the default range when no wallet tokens are present; `renderCarousel()` now falls back to the full `DEFAULT_CAROUSEL_TOKEN_IDS` instead of hiding the carousel. (changes in `main.js`)
- Keep wallet lookup behavior but store results in `walletOwnedTokenIds` and render based on the active mode via `renderCarousel(getCarouselTokenIdsForMode())`; update `doWalletLookup()` to populate that array. (changes in `main.js`)
- Ensure carousel interactions still call `loadFriendsies(id)` immediately (click handlers, paging via `scrollCarouselByPage`) so center/active token changes load the model even before any wallet action. (existing handlers preserved in `main.js`)
- Update wallet-tab copy to remove wallet-first instructions and update status text during lookup (changes in `index.html` and a small status text change in `main.js`).

### Testing
- Ran `node --check main.js` to validate JavaScript syntax and it succeeded.
- Served the app locally with `python3 -m http.server --directory /workspace/garden_reborn` and inspected the running UI to verify the carousel is visible at boot; this server run completed successfully.
- Captured a Playwright-driven screenshot by navigating to the local server (`page.goto(..., wait_until='domcontentloaded')`) to confirm the always-visible default-range carousel rendering and the updated UI copy; the screenshot capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842e4b21208323a531bdeaed03aed8)