### PR TITLE
Refactor token carousel to center-snap scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,9 +395,7 @@
       </button>
 
       <div id="carousel" class="carousel" aria-hidden="true">
-        <button id="carouselPrevBtn" class="carouselNav" type="button" aria-label="Previous tokens">‹</button>
-        <div class="carouselTrack" id="carouselTrack" role="list"></div>
-        <button id="carouselNextBtn" class="carouselNav" type="button" aria-label="Next tokens">›</button>
+        <div class="carouselTrack" id="carouselTrack" role="listbox" aria-label="Token picker"></div>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -171,8 +171,8 @@ canvas {
 .tabBtn:active { transform: translateY(0); }
 
 .tabBtn[aria-selected="true"] {
-  background: rgba(33, 150, 83, 0.90);
-  border-color: rgba(33, 150, 83, 0.95);
+  background: linear-gradient(180deg, rgba(74,163,255,0.96), rgba(30,122,219,0.96));
+  border-color: rgba(166,216,255,0.95);
   color: #fff;
 }
 
@@ -213,7 +213,7 @@ canvas {
     left: 10px;
     right: 10px;
     top: auto;
-    bottom: 10px;
+    bottom: 96px;
     width: auto;
     max-width: none;
     padding: 10px;
@@ -298,8 +298,8 @@ canvas {
 .btn:active { transform: translateY(0); }
 
 .btn.primary {
-  background: rgba(33, 150, 83, 0.90);
-  border-color: rgba(33, 150, 83, 0.95);
+  background: linear-gradient(180deg, rgba(74,163,255,0.96), rgba(30,122,219,0.96));
+  border-color: rgba(166,216,255,0.95);
   color: #fff;
 }
 .btn.danger {
@@ -409,16 +409,17 @@ kbd {
   pointer-events: auto;
   position: absolute;
   left: 50%;
-  bottom: 14px;
+  bottom: 108px;
   transform: translate(-50%, 110%); /* fully hidden when closed */
-  height: 64px;
+  height: 78px;
   width: fit-content;
   max-width: calc(100vw - 28px);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.78);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.12);
-  border: 1px solid rgba(255,255,255,0.55);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.58);
+  backdrop-filter: blur(18px) saturate(1.2);
+  -webkit-backdrop-filter: blur(18px) saturate(1.2);
+  box-shadow: 0 16px 40px rgba(16,22,48,0.18), inset 0 1px 0 rgba(255,255,255,0.45);
+  border: 1px solid rgba(255,255,255,0.38);
   overflow: hidden;
   display: none; /* enabled after wallet lookup */
   opacity: 1;
@@ -435,13 +436,6 @@ kbd {
   .carousel.hoverReveal:hover {
     transform: translate(-50%, 0);
   }
-}
-
-/* Nav arrows: only show when open (mobile) or when hovered (desktop) */
-.carouselNav { display: none; }
-.carousel.open .carouselNav { display: grid; }
-@media (hover: hover) {
-  .carousel:hover .carouselNav { display: grid; }
 }
 
 .carouselPeek {
@@ -464,35 +458,20 @@ kbd {
 }
 
 .carouselPeek.open {
-  bottom: 84px; /* sits just above the open carousel */
+  bottom: 178px; /* sits just above the open carousel */
 }
-
-.carouselNav {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 2;
-  width: 34px;
-  height: 34px;
-  border-radius: 12px;
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.75);
-  cursor: pointer;
-  place-items: center;
-}
-.carouselNav:hover { transform: translateY(-50%) translateY(-1px); }
-
-.carouselNav#carouselPrevBtn { left: 8px; }
-.carouselNav#carouselNextBtn { right: 8px; }
 
 .carouselTrack {
   height: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 10px 46px; /* room for nav buttons */
-  overflow: hidden; /* windowed list, no scrolling */
+  gap: 10px;
+  padding: 14px calc(50% - 54px);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .carouselTrack::-webkit-scrollbar { height: 8px; }
@@ -503,11 +482,15 @@ kbd {
 
 .carouselItem {
   flex: 0 0 auto;
+  min-width: 108px;
+  text-align: center;
   scroll-snap-align: center;
-  padding: 8px 10px;
+  scroll-snap-stop: always;
+  padding: 10px 14px;
   border-radius: 999px;
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.75);
+  border: 1px solid rgba(255,255,255,0.42);
+  background: linear-gradient(180deg, rgba(255,255,255,0.58), rgba(255,255,255,0.28));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.55), 0 6px 18px rgba(20, 28, 60, 0.12);
   font-size: 12px;
   cursor: pointer;
   user-select: none;
@@ -516,8 +499,8 @@ kbd {
 .carouselItem:hover { transform: translateY(-1px); }
 
 .carouselItem.active {
-  background: rgba(33, 150, 83, 0.90);
-  border-color: rgba(33, 150, 83, 0.95);
+  background: linear-gradient(180deg, rgba(74,163,255,0.96), rgba(30,122,219,0.96));
+  border-color: rgba(166,216,255,0.95);
   color: #fff;
 }
 
@@ -624,12 +607,12 @@ kbd {
   .carousel {
     left: 10px;
     right: 10px;
-    bottom: 10px;
+    bottom: 96px;
     width: auto;
     max-width: none;
     transform: translate(0, 110%); /* override desktop centering translateX(-50%) */
   }
   .carousel.open { transform: translate(0, 0); }
   .carouselPeek { bottom: 10px; }
-  .carouselPeek.open { bottom: 80px; }
+  .carouselPeek.open { bottom: 176px; }
 }


### PR DESCRIPTION
### Motivation
- Replace legacy arrow-paged/dial carousel with a minimal horizontal track that supports inertial swiping and center snapping positioned near the character feet. 
- Make the centered card the single source-of-truth for selection so token loads happen when the track settles, not on every pixel of drag. 
- Improve mobile touch feel and visuals using glassmorphism / iOS-like styling tokens while preserving keyboard accessibility fallback. 

### Description
- Reworked DOM: replaced arrow-based carousel markup with a minimal track/listbox (`#carouselTrack`) in `index.html`. 
- Styling updates in `style.css` to enable inertial horizontal swipe and center snapping (`overflow-x: auto`, `scroll-snap-type: x mandatory`, `scroll-snap-align: center`), refreshed glassmorphism tokens, and repositioning of the carousel near the lower character region. 
- JS changes in `main.js` to make center-snap the source of truth by removing legacy window/page logic and arrow-page behavior and adding: `getCarouselCenteredIndex`, `onCarouselSnap`, `queueCarouselSnapResolution` (debounce), `scrollCarouselToTokenId`, and a refactored `updateCarouselActive` that toggles per-item active state; click now scrolls an item to center then resolves via the debounced snap handler. 
- Keyboard fallback retained: `ArrowLeft`/`ArrowRight` now scroll to prev/next token and trigger the snap-resolution flow rather than directly loading tokens. 

### Testing
- `node --check main.js` — syntax check passed. 
- Served the site with `python -m http.server 4173` and used a Playwright script to open the page, open the carousel, and capture a screenshot for visual verification (screenshot created as an artifact). 
- Confirmed arrow controls are removed with repository search (grep) for `carouselPrevBtn|carouselNextBtn|carouselNav`. All automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698433055c2483239ddbbd22b67a2d5a)