### PR TITLE
Minimalist UI mode: sandwich menu + guard legacy wallet/anim/debug surfaces behind flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ to the animated head without lag.
 
 ---
 
+## Minimalist mode (default)
+
+The UI now boots in a minimalist mode by default so the viewer does not depend on legacy tool surfaces.
+
+- `FEATURE_WALLET_UI = false` keeps wallet lookup UI wiring off (no automatic `/api/friendsiesTokens` call on default boot).
+- `FEATURE_ANIM_UI = false` keeps animation control wiring off.
+- `FEATURE_DEBUG_LOG = false` keeps transcript/look/export/debug wiring off.
+
+To re-enable those surfaces, flip the flags at the top of `main.js` to `true`.
+
+---
+
 ## Features
 
 - ✅ Load fRiENDSiES by token ID (1–10000)

--- a/index.html
+++ b/index.html
@@ -18,17 +18,11 @@
         aria-label="Toggle UI"
         title="Toggle UI (H)"
       >
-        <!-- sliders icon (cleaner than the gear) -->
+        <!-- minimalist sandwich icon -->
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M4 6h10" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M18 6h2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M4 12h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M12 12h8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M4 18h12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M18 18h2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M14 4v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M8 10v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M16 16v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          <path d="M4 7h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          <path d="M4 12h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          <path d="M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
         </svg>
       </button>
 
@@ -362,6 +356,11 @@
           ></div>
         </div>
       </div>
+
+      <section id="toolSheet" class="toolSheet" hidden aria-hidden="true">
+        <div class="toolSheetTitle">Tools</div>
+        <div class="toolSheetBody">Minimal mode is active. This sheet is reserved for future tools.</div>
+      </section>
 
       <!-- Transcript / pseudo console (collapsible) -->
       <div id="logPanel" class="logPanel" aria-hidden="false">

--- a/style.css
+++ b/style.css
@@ -83,6 +83,29 @@ canvas {
 .uiToggle:hover { transform: translateY(-1px); }
 .uiToggle:active { transform: translateY(0); }
 
+.toolSheet {
+  pointer-events: auto;
+  position: absolute;
+  left: 66px;
+  top: 70px;
+  width: min(320px, calc(100vw - 80px));
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.72);
+  border: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+  backdrop-filter: blur(8px);
+}
+.toolSheetTitle {
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.toolSheetBody {
+  font-size: 12px;
+  opacity: 0.8;
+}
+
 /* Main panel */
 .panel {
   pointer-events: auto;


### PR DESCRIPTION
### Motivation

- Reduce default UI surface and avoid requiring backend wallet lookups on boot by shipping a minimalist viewer-first mode.
- Make legacy tools (wallet lookup, animation controls, debug transcript/export) opt-in behind simple flags so future experiments can be re-enabled without changing DOM wiring.

### Description

- Added a minimalist “sandwich” menu icon and a hidden lightweight `toolSheet` container in `index.html` and corresponding styles in `style.css` for future tools. 
- Introduced feature flags in `main.js`: `FEATURE_WALLET_UI`, `FEATURE_ANIM_UI`, and `FEATURE_DEBUG_LOG`, all defaulting to `false` to enable minimalist boot. 
- Moved wallet/anim/transcript/export wiring into guarded initializers (`initWalletUiBindings()`, `initAnimUiBindings()`, `initDebugUiBindings()`) and added `initLegacyToolSurfaces()` to hide/show legacy tabs and panels based on flags. 
- Updated `walletUi` and `setWalletUiState()` to manage `walletTokensSelect`/`walletLoadSelectedBtn` population and disabled state, and gated deep-link wallet auto-lookup in the boot sequence behind `FEATURE_WALLET_UI` while leaving the backend `/api/friendsiesTokens` endpoint intact. 
- Added small README docs describing minimalist mode and how to re-enable wallet/anim/debug surfaces by flipping the flags at the top of `main.js`.

### Testing

- Ran `node --check main.js` to validate no syntax errors and it succeeded. 
- Launched a local static server with `python -m http.server` and verified the page loads and assets are served successfully. 
- Captured a Playwright screenshot of the running app to validate the minimalist UI rendering and artifact generation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698439ac225083239e6af309a3f32269)