### PR TITLE
Switch carousel to wallet-owned mode after successful wallet lookup

### DIFF
--- a/main.js
+++ b/main.js
@@ -2612,10 +2612,14 @@ async function doWalletLookup() {
 
     walletOwnedTokenIds = tokenIds;
 
+    // When wallet lookup succeeds, switch dial source to wallet-owned IDs.
+    // If wallet has no tokens, fall back to the default 1..10000 range.
+    setCarouselMode(
+      tokenIds.length ? CAROUSEL_MODES.walletOwned : CAROUSEL_MODES.defaultRange
+    );
+
     // reset carousel init for new wallet results
     if (sceneUiAdapter.tokenCarousel) delete sceneUiAdapter.tokenCarousel.dataset.carouselInit;
-
-    renderCarousel(getCarouselTokenIdsForMode());
 
     const who = data.ownerResolved || data.ownerInput || input;
     const display =
@@ -2662,8 +2666,8 @@ async function doWalletLookup() {
     console.error(err);
     lastWalletLookup = null;
     walletOwnedTokenIds = [];
+    setCarouselMode(CAROUSEL_MODES.defaultRange);
     syncOwnedModeLabels();
-    renderCarousel(getCarouselTokenIdsForMode());
     setWalletUiState({ busy: false, tokenIds: [], hint: "Lookup failed." });
     setStatus("wallet lookup failed ❌");
     logLine(`wallet lookup failed ❌ ${err?.message || err}`, "err");


### PR DESCRIPTION
### Motivation
- The carousel/dial remained in the default `1..10000` range after doing a wallet lookup, so selecting a wallet did not restrict the dial to just the tokens owned by that wallet.

### Description
- After assigning `walletOwnedTokenIds`, call `setCarouselMode(...)` to switch to `CAROUSEL_MODES.walletOwned` when the lookup returns tokens, otherwise fall back to `CAROUSEL_MODES.defaultRange` for empty results.
- On lookup failure clear/reset `walletOwnedTokenIds` and explicitly call `setCarouselMode(CAROUSEL_MODES.defaultRange)` to avoid stale state, and remove the redundant `renderCarousel(...)` calls in the lookup path.

### Testing
- Ran `node --check main.js` to verify syntax, which succeeded. 
- Launched a local static server (`python3 -m http.server 4173`) and captured a Playwright screenshot to exercise the UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842c1641e883238010eeb3630873ca)