### PR TITLE
Replace legacy UI with GlideJS carousel and minimalist glassmorphism overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,397 +5,79 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>fRiENDSiES Toy Box</title>
     <link rel="stylesheet" href="/style.css?v=2026-02-03c" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@glidejs/glide@3.6.0/dist/css/glide.core.min.css"
+    />
   </head>
 
   <body>
-    <div id="ui">
-      <div id="toast" class="toast" aria-live="polite" aria-atomic="true"></div>
-      <!-- Toggle ALL UI (controls + transcript) -->
-      <button
-        id="uiToggleBtn"
-        class="uiToggle"
-        type="button"
-        aria-label="Toggle UI"
-        title="Toggle UI (H)"
-      >
-        <!-- sliders icon (cleaner than the gear) -->
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M4 6h10" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M18 6h2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M4 12h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M12 12h8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M4 18h12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M18 18h2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M14 4v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M8 10v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-          <path d="M16 16v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-        </svg>
-      </button>
-
-      <!-- Controls panel -->
-      <div id="panel" class="panel" aria-hidden="false">
-        <div class="panelHeader">
-          <div class="brand">
-            <div class="logo" aria-hidden="true">🧸</div>
-            <div class="brandText">
-              <div class="title">fRiENDSiES Toy Box</div>
-              <div class="subtitle">Viewer + anim test (pano bg + EXR env)</div>
-            </div>
+    <div id="ui" class="ui">
+      <div id="tokenCarousel" class="glassCarousel" aria-label="Token picker">
+        <div class="glide" id="tokenGlide">
+          <div class="glide__track" data-glide-el="track">
+            <ul class="glide__slides" id="tokenSlides"></ul>
           </div>
-          <div id="status" class="status">booting…</div>
-        </div>
-
-        <!-- Tabbed settings (keeps existing control element IDs for JS wiring) -->
-        <div class="tabs" role="tablist" aria-label="Settings" data-tabs="settings">
-          <button
-            class="tabBtn"
-            type="button"
-            role="tab"
-            id="settingsTabToken"
-            aria-selected="true"
-            aria-controls="settingsPanelToken"
-          >
-            Token
-          </button>
-          <button
-            class="tabBtn"
-            type="button"
-            role="tab"
-            id="settingsTabAnim"
-            aria-selected="false"
-            aria-controls="settingsPanelAnim"
-            tabindex="-1"
-          >
-            Anim
-          </button>
-          <button
-            class="tabBtn"
-            type="button"
-            role="tab"
-            id="settingsTabLook"
-            aria-selected="false"
-            aria-controls="settingsPanelLook"
-            tabindex="-1"
-          >
-            Look
-          </button>
-          <button
-            class="tabBtn"
-            type="button"
-            role="tab"
-            id="settingsTabWallet"
-            aria-selected="false"
-            aria-controls="settingsPanelWallet"
-            tabindex="-1"
-          >
-            Wallet
-          </button>
-          <button
-            class="tabBtn"
-            type="button"
-            role="tab"
-            id="settingsTabExport"
-            aria-selected="false"
-            aria-controls="settingsPanelExport"
-            tabindex="-1"
-          >
-            Export
-          </button>
-
-          <button
-            class="tabBtn"
-            type="button"
-            role="tab"
-            id="settingsTabLog"
-            aria-selected="false"
-            aria-controls="settingsPanelLog"
-            tabindex="-1"
-          >
-            Log
-          </button>
-
-          <button
-            id="settingsCompactBtn"
-            class="tabBtn compactBtn"
-            type="button"
-            aria-label="Toggle controls"
-            title="Toggle controls"
-          >
-            ▾
-          </button>
-        </div>
-
-        <div class="tabPanels">
-          <!-- TOKEN -->
-          <div
-            id="settingsPanelToken"
-            class="tabPanel"
-            role="tabpanel"
-            tabindex="0"
-            aria-labelledby="settingsTabToken"
-          >
-            <div class="row">
-              <div class="pill">
-                <span class="pillLabel">ID</span>
-                <input type="number" id="friendsiesId" min="1" max="10000" value="5" />
-              </div>
-
-              <button id="loadBtn" class="btn primary">Load</button>
-              <button id="randomBtn" class="btn"><span id="randomBtnText">🎲 Random</span></button>
-
-              <label class="chip" title="Auto-random every 4 seconds">
-                <input type="checkbox" id="autoRandomOn" />
-                <span id="autoRandomLabelText">✅ Auto</span>
-              </label>
-            </div>
-          </div>
-
-          <!-- ANIM -->
-          <div
-            id="settingsPanelAnim"
-            class="tabPanel"
-            role="tabpanel"
-            tabindex="0"
-            aria-labelledby="settingsTabAnim"
-            hidden
-          >
-            <div class="row">
-              <div class="pill wide">
-                <span class="pillLabel">Anim</span>
-                <select id="animSelect"></select>
-              </div>
-
-              <button id="playBtn" class="btn primary">▶ Play</button>
-              <button id="stopBtn" class="btn danger">■ Stop</button>
-
-              <label class="chip">
-                <input type="checkbox" id="orbitOn" checked />
-                🛰 Orbit
-              </label>
-
-              <label class="chip">
-                <input type="checkbox" id="autoRotateOn" />
-                🔄 Auto
-              </label>
-            </div>
-          </div>
-
-          <!-- LOOK -->
-          <div
-            id="settingsPanelLook"
-            class="tabPanel"
-            role="tabpanel"
-            tabindex="0"
-            aria-labelledby="settingsTabLook"
-            hidden
-          >
-            <div class="lookPanel collapsed" id="lookPanel">
-              <button
-                id="lookToggleBtn"
-                class="panelToggle"
-                type="button"
-                aria-expanded="false"
-                aria-controls="lookControls"
-              >
-                <span>🎨 Look Tuning</span>
-                <span class="panelChevron" aria-hidden="true">▾</span>
-              </button>
-              <div id="lookControls" class="lookControls" aria-hidden="true">
-                <div class="sliderRow">
-                  <label for="lookExposure">toneMappingExposure</label>
-                  <input
-                    type="range"
-                    id="lookExposure"
-                    min="0.6"
-                    max="1.8"
-                    step="0.01"
-                    data-look-control="toneMappingExposure"
-                  />
-                  <span class="sliderValue" data-look-value="toneMappingExposure"></span>
-                </div>
-                <div class="sliderRow">
-                  <label for="lookHemi">hemiIntensity</label>
-                  <input
-                    type="range"
-                    id="lookHemi"
-                    min="0"
-                    max="1"
-                    step="0.01"
-                    data-look-control="hemiIntensity"
-                  />
-                  <span class="sliderValue" data-look-value="hemiIntensity"></span>
-                </div>
-                <div class="sliderRow">
-                  <label for="lookAmbient">ambientIntensity</label>
-                  <input
-                    type="range"
-                    id="lookAmbient"
-                    min="0"
-                    max="1"
-                    step="0.01"
-                    data-look-control="ambientIntensity"
-                  />
-                  <span class="sliderValue" data-look-value="ambientIntensity"></span>
-                </div>
-                <div class="sliderRow">
-                  <label for="lookKey">keyLightIntensity</label>
-                  <input
-                    type="range"
-                    id="lookKey"
-                    min="0"
-                    max="2"
-                    step="0.01"
-                    data-look-control="keyLightIntensity"
-                  />
-                  <span class="sliderValue" data-look-value="keyLightIntensity"></span>
-                </div>
-                <div class="sliderRow">
-                  <label for="lookRim">rimLightIntensity</label>
-                  <input
-                    type="range"
-                    id="lookRim"
-                    min="0"
-                    max="2"
-                    step="0.01"
-                    data-look-control="rimLightIntensity"
-                  />
-                  <span class="sliderValue" data-look-value="rimLightIntensity"></span>
-                </div>
-                <div class="sliderRow">
-                  <label for="lookEnv">envIntensityMultiplier</label>
-                  <input
-                    type="range"
-                    id="lookEnv"
-                    min="0"
-                    max="3"
-                    step="0.05"
-                    data-look-control="envIntensityMultiplier"
-                  />
-                  <span class="sliderValue" data-look-value="envIntensityMultiplier"></span>
-                </div>
-                <div class="sliderRow">
-                  <label for="lookEmissive">emissiveIntensityMultiplier</label>
-                  <input
-                    type="range"
-                    id="lookEmissive"
-                    min="0"
-                    max="4"
-                    step="0.05"
-                    data-look-control="emissiveIntensityMultiplier"
-                  />
-                  <span class="sliderValue" data-look-value="emissiveIntensityMultiplier"></span>
-                </div>
-                <div class="lookActions">
-                  <button id="copyLookBtn" class="btn">📋 Copy Current Look</button>
-                  <span class="hintText">Press <kbd>P</kbd> to print JSON.</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- WALLET -->
-          <div
-            id="settingsPanelWallet"
-            class="tabPanel"
-            role="tabpanel"
-            tabindex="0"
-            aria-labelledby="settingsTabWallet"
-            hidden
-          >
-            <div class="row">
-              <div class="pill wide">
-                <span class="pillLabel">Wallet / ENS</span>
-                <input
-                  type="text"
-                  id="walletInput"
-                  placeholder="0x… or pizzalord.eth"
-                  spellcheck="false"
-                  autocomplete="off"
-                />
-              </div>
-
-              <button id="walletLookupBtn" class="btn primary">Lookup</button>
-              <button id="walletDownloadJsonBtn" class="btn" title="Download results as JSON" disabled>
-                ⬇ Wallet JSON
-              </button>
-            </div>
-
-            <div class="row">
-              <div class="pill wide">
-                <span class="pillLabel">Wallet-owned Friendsies</span>
-                <select id="walletTokensSelect" disabled>
-                  <option value="">(wallet lookup optional)</option>
-                </select>
-              </div>
-
-              <button id="walletLoadSelectedBtn" class="btn">Load Highlighted</button>
-
-              <span class="hintText" id="walletHint">Tip: browse #1–#10000 in the carousel; wallet lookup is optional for owned-token overlays.</span>
-            </div>
-          </div>
-
-          <!-- EXPORT -->
-          <div
-            id="settingsPanelExport"
-            class="tabPanel"
-            role="tabpanel"
-            tabindex="0"
-            aria-labelledby="settingsTabExport"
-            hidden
-          >
-            <div class="row tiny">
-              <button id="printTraitsBtn" class="btn">🧩 Trait URLs</button>
-              <button id="printRigBtn" class="btn">🛠 Rig Bones</button>
-              <button id="downloadGlbBtn" class="btn primary">⬇ Download Rig (.glb)</button>
-              <span class="hintText">Tip: press <kbd>H</kbd> to hide UI, <kbd>L</kbd> to collapse transcript.</span>
-            </div>
-          </div>
-
-          <!-- LOG (mobile: transcript is moved here via JS) -->
-          <div
-            id="settingsPanelLog"
-            class="tabPanel"
-            role="tabpanel"
-            tabindex="0"
-            aria-labelledby="settingsTabLog"
-            hidden
-          ></div>
         </div>
       </div>
 
-      <!-- Transcript / pseudo console (collapsible) -->
-      <div id="logPanel" class="logPanel" aria-hidden="false">
-        <div class="logHeader">
-          <div class="logTitle">📟 Transcript</div>
-          <div class="logActions">
-            <button id="clearLogBtn" class="iconBtn" type="button" title="Clear transcript">Clear</button>
-            <button
-              id="logToggleBtn"
-              class="iconBtn"
-              type="button"
-              aria-label="Toggle transcript"
-              title="Toggle transcript (L)"
-            >
-              <span id="logChevron" aria-hidden="true">▾</span>
-            </button>
-          </div>
+      <div class="menuStack">
+        <button id="hamburger" class="hamburger" type="button" aria-label="Menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+
+        <div id="menu" class="menu" aria-hidden="true">
+          <button class="menuIcon" type="button" data-panel="find" aria-label="Find">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="11" cy="11" r="6.5" stroke="currentColor" stroke-width="2" fill="none" />
+              <path d="M16.5 16.5L21 21" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </button>
+          <button class="menuIcon" type="button" data-panel="share" aria-label="Share">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M4 7h16v10H4z"
+                stroke="currentColor"
+                stroke-width="2"
+                fill="none"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M4 7l8 6 8-6"
+                stroke="currentColor"
+                stroke-width="2"
+                fill="none"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <button class="menuIcon" type="button" data-panel="vibe" aria-label="Vibe">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 3l2.5 5 5.5.8-4 3.9.9 5.5-4.9-2.6-4.9 2.6.9-5.5-4-3.9 5.5-.8z"
+                stroke="currentColor"
+                stroke-width="2"
+                fill="none"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </div>
-        <div id="log" class="log"></div>
       </div>
 
-      <!-- Bottom carousel (wallet tokens) -->
-      <button
-        id="carouselPeekBtn"
-        class="carouselPeek"
-        type="button"
-        aria-label="Toggle token carousel"
-        title="Toggle tokens"
-      >
-        ▴
-      </button>
-
-      <div id="carousel" class="carousel" aria-hidden="true">
-        <div class="carouselTrack" id="carouselTrack" role="listbox" aria-label="Token picker"></div>
+      <div id="panel-find" class="sheet" aria-hidden="true">
+        <div class="sheetTitle">Find</div>
+        <div class="sheetBody">Search sheet placeholder</div>
+      </div>
+      <div id="panel-share" class="sheet" aria-hidden="true">
+        <div class="sheetTitle">Share</div>
+        <div class="sheetBody">Share sheet placeholder</div>
+      </div>
+      <div id="panel-vibe" class="sheet" aria-hidden="true">
+        <div class="sheetTitle">Vibe</div>
+        <div class="sheetBody">Dev/settings placeholder</div>
       </div>
     </div>
 
@@ -412,6 +94,7 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/EXRLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/exporters/GLTFExporter.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@glidejs/glide@3.6.0/dist/glide.min.js"></script>
 
     <script src="/main.js?v=2026-02-03c"></script>
   </body>

--- a/style.css
+++ b/style.css
@@ -1,9 +1,10 @@
 /* Base */
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   height: 100%;
-  height: 100dvh; /* modern mobile: dynamic viewport height */
+  height: 100dvh;
   overflow: hidden;
   background: #ffffff;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial,
@@ -16,603 +17,207 @@ canvas {
   height: 100dvh;
 }
 
-/* UI overlay */
-#ui {
+.ui {
   position: fixed;
   inset: 0;
-  pointer-events: none; /* orbit still works on canvas */
+  pointer-events: none;
 }
 
-/* Toast (non-blocking) */
-.toast {
-  position: absolute;
+/* Glassmorphism helpers */
+:root {
+  --glass-bg: rgba(255, 255, 255, 0.58);
+  --glass-border: rgba(255, 255, 255, 0.4);
+  --glass-shadow: 0 18px 50px rgba(14, 20, 42, 0.18);
+}
+
+/* Carousel */
+.glassCarousel {
+  pointer-events: auto;
+  position: fixed;
   left: 50%;
-  top: 14px;
+  bottom: 34px;
   transform: translateX(-50%);
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 160ms ease;
-  padding: 8px 12px;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 600;
-  color: rgba(0,0,0,0.82);
-  background: rgba(255,255,255,0.82);
-  border: 1px solid rgba(0,0,0,0.08);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.10);
-  z-index: 6;
-}
-.toast.show { opacity: 1; }
-
-
-/* “Hide UI” state */
-#ui.uiHidden .panel,
-#ui.uiHidden .logPanel {
-  opacity: 0;
-  transform: translateY(-6px);
-  pointer-events: none;
-}
-
-/* Transcript collapsed state */
-#ui.logCollapsed #log {
-  display: none;
-}
-#ui.logCollapsed #logChevron {
-  transform: rotate(-90deg);
-  display: inline-block;
-}
-
-/* Gear toggle button (always available) */
-.uiToggle {
-  pointer-events: auto;
-  position: absolute;
-  left: 14px;
-  top: 14px;
-  width: 42px;
-  height: 42px;
-  border-radius: 14px;
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.75);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.10);
-  cursor: pointer;
-  display: grid;
-  place-items: center;
-}
-.uiToggle:hover { transform: translateY(-1px); }
-.uiToggle:active { transform: translateY(0); }
-
-/* Main panel */
-.panel {
-  pointer-events: auto;
-  position: absolute;
-  left: 66px; /* leaves room for gear */
-  top: 14px;
-  width: min(760px, calc(100vw - 80px));
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.78);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.12);
-  border: 1px solid rgba(255,255,255,0.55);
-  padding: 12px;
-  transition: opacity 140ms ease, transform 140ms ease;
-}
-
-.panelHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 2px 2px 10px 2px;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-}
-
-.logo {
-  width: 34px;
-  height: 34px;
-  border-radius: 10px;
-  display: grid;
-  place-items: center;
-  background: rgba(0,0,0,0.05);
-}
-
-.brandText { min-width: 0; }
-
-.title {
-  font-weight: 700;
-  font-size: 14px;
-  line-height: 1.1;
-}
-
-.subtitle {
-  font-size: 12px;
-  opacity: 0.7;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 520px;
-}
-
-.status {
-  font-size: 12px;
-  opacity: 0.8;
-  white-space: nowrap;
-}
-
-/* Controls */
-
-/* Settings tabs */
-.tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding: 0 2px 6px 2px;
-  margin: 0 0 2px 0;
-}
-
-.tabBtn {
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.70);
-  border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 12px;
-  cursor: pointer;
-  user-select: none;
-}
-
-.tabBtn:hover { transform: translateY(-1px); }
-.tabBtn:active { transform: translateY(0); }
-
-.tabBtn[aria-selected="true"] {
-  background: linear-gradient(180deg, rgba(74,163,255,0.96), rgba(30,122,219,0.96));
-  border-color: rgba(166,216,255,0.95);
-  color: #fff;
-}
-
-.tabPanels { margin-top: 2px; }
-.tabPanel .row:first-child { margin-top: 0; }
-
-/* Compact settings mode: ultra-minimal tabs-only dock to maximize 3D visibility */
-.panel.compact {
-  width: auto;
-  max-width: 360px;
-  padding: 8px;
-}
-.panel.compact .panelHeader { display: none; }
-.panel.compact .tabPanels { display: none; }
-
-.compactBtn {
-  margin-left: auto;
-  width: 34px;
-  padding: 6px 0;
-  font-weight: 700;
-}
-.panel.compact .compactBtn {
-  transform: rotate(-90deg);
-}
-
-/* When transcript is moved into a tab panel on mobile, it must behave like normal flow */
-.tabPanel .logPanel {
-  position: static;
-  left: auto;
-  bottom: auto;
-  width: auto;
-  transform: none;
-}
-
-@media (max-width: 520px) {
-  /* Mobile bottom sheet: controls live at the bottom to avoid covering the face/torso */
-  .panel {
-    left: 10px;
-    right: 10px;
-    top: auto;
-    bottom: 96px;
-    width: auto;
-    max-width: none;
-    padding: 10px;
-  }
-
-  .tabs {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .tabs::-webkit-scrollbar { height: 6px; }
-
-  /* Collapsed-by-default on mobile: only the tab strip/dock shows */
-  .panel.compact {
-    padding: 8px;
-  }
-}
-
-
-.row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
-}
-.row.tiny { margin-top: 10px; gap: 10px; }
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border-radius: 12px;
-  background: rgba(0,0,0,0.04);
-  border: 1px solid rgba(0,0,0,0.06);
-}
-
-.pill.wide {
-  flex: 1 1 280px;
-  min-width: 260px;
-}
-
-.pillLabel { font-size: 12px; opacity: 0.7; }
-
-.pill input[type="number"],
-.pill input[type="text"],
-.pill select {
-  border: none;
-  outline: none;
-  background: transparent;
-  font-size: 13px;
-  width: 130px;
-}
-
-.pill input[type="text"] {
-  width: 100%;
-  min-width: 220px;
-}
-
-.pill.wide select {
-  width: 100%;
-  min-width: 220px;
-}
-
-.btn {
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.75);
-  border-radius: 12px;
-  padding: 8px 12px;
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.btn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-  transform: none !important;
-}
-.btn:hover { transform: translateY(-1px); }
-.btn:active { transform: translateY(0); }
-
-.btn.primary {
-  background: linear-gradient(180deg, rgba(74,163,255,0.96), rgba(30,122,219,0.96));
-  border-color: rgba(166,216,255,0.95);
-  color: #fff;
-}
-.btn.danger {
-  background: rgba(235, 87, 87, 0.92);
-  border-color: rgba(235, 87, 87, 0.95);
-  color: #fff;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
-  border-radius: 999px;
-  background: rgba(0,0,0,0.04);
-  border: 1px solid rgba(0,0,0,0.06);
-  font-size: 12px;
-  user-select: none;
-}
-.chip input { accent-color: #2d9cdb; }
-
-.hintText {
-  font-size: 12px;
-  opacity: 0.65;
-}
-
-/* Look tuning panel */
-.lookPanel {
-  margin-top: 10px;
-  border-radius: 12px;
-  border: 1px solid rgba(0,0,0,0.06);
-  background: rgba(255,255,255,0.65);
-  overflow: hidden;
-}
-
-.panelToggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-  color: rgba(0,0,0,0.78);
-}
-
-.panelToggle:hover { background: rgba(0,0,0,0.03); }
-
-.panelChevron {
-  transition: transform 140ms ease;
-}
-
-.lookPanel.collapsed .panelChevron {
-  transform: rotate(-90deg);
-}
-
-.lookControls {
-  padding: 10px;
-  border-top: 1px solid rgba(0,0,0,0.06);
-  display: grid;
-  gap: 8px;
-}
-
-.lookPanel.collapsed .lookControls {
-  display: none;
-}
-
-.sliderRow {
-  display: grid;
-  grid-template-columns: minmax(140px, 1fr) 1.6fr minmax(42px, auto);
-  align-items: center;
-  gap: 10px;
-  font-size: 12px;
-}
-
-.sliderRow input[type="range"] {
-  width: 100%;
-}
-
-.sliderValue {
-  font-variant-numeric: tabular-nums;
-  text-align: right;
-  opacity: 0.7;
-}
-
-.lookActions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-kbd {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 6px;
-  border: 1px solid rgba(0,0,0,0.12);
-  background: rgba(255,255,255,0.7);
-}
-
-/* Bottom carousel */
-.carousel {
-  pointer-events: auto;
-  position: absolute;
-  left: 50%;
-  bottom: 108px;
-  transform: translate(-50%, 110%); /* fully hidden when closed */
-  height: 78px;
-  width: fit-content;
-  max-width: calc(100vw - 28px);
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.58);
+  width: min(680px, calc(100vw - 32px));
+  padding: 12px 18px;
+  border-radius: 28px;
+  background: var(--glass-bg);
   backdrop-filter: blur(18px) saturate(1.2);
   -webkit-backdrop-filter: blur(18px) saturate(1.2);
-  box-shadow: 0 16px 40px rgba(16,22,48,0.18), inset 0 1px 0 rgba(255,255,255,0.45);
-  border: 1px solid rgba(255,255,255,0.38);
-  overflow: hidden;
-  display: none; /* enabled after wallet lookup */
-  opacity: 1;
-  transition: transform 180ms ease;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  z-index: 5;
 }
 
-/* Open state */
-.carousel.open {
-  transform: translate(-50%, 0);
-}
-
-/* Desktop hover reveal near bottom */
-@media (hover: hover) {
-  .carousel.hoverReveal:hover {
-    transform: translate(-50%, 0);
-  }
-}
-
-.carouselPeek {
-  pointer-events: auto;
-  position: absolute;
-  left: 50%;
-  bottom: 14px;
-  transform: translateX(-50%);
-  z-index: 4;
-  width: 44px;
-  height: 26px;
-  border-radius: 999px;
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.75);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.10);
-  cursor: pointer;
-  line-height: 1;
-  display: none; /* enabled after wallet lookup */
-}
-
-.carouselPeek.open {
-  bottom: 178px; /* sits just above the open carousel */
-}
-
-.carouselTrack {
-  height: 100%;
-  display: flex;
+.glide__slides {
   align-items: center;
-  gap: 10px;
-  padding: 14px calc(50% - 54px);
-  overflow-x: auto;
-  overflow-y: hidden;
-  scroll-snap-type: x mandatory;
-  overscroll-behavior-x: contain;
-  -webkit-overflow-scrolling: touch;
 }
 
-.carouselTrack::-webkit-scrollbar { height: 8px; }
-.carouselTrack::-webkit-scrollbar-thumb {
-  background: rgba(0,0,0,0.15);
-  border-radius: 999px;
-}
-
-.carouselItem {
-  flex: 0 0 auto;
-  min-width: 108px;
+.glide__slide {
   text-align: center;
-  scroll-snap-align: center;
-  scroll-snap-stop: always;
-  padding: 10px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.42);
-  background: linear-gradient(180deg, rgba(255,255,255,0.58), rgba(255,255,255,0.28));
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.55), 0 6px 18px rgba(20, 28, 60, 0.12);
-  font-size: 12px;
-  cursor: pointer;
-  user-select: none;
+  font-size: 13px;
+  color: rgba(20, 24, 38, 0.6);
+  opacity: 0.55;
+  transition: transform 160ms ease, opacity 160ms ease;
 }
 
-.carouselItem:hover { transform: translateY(-1px); }
-
-.carouselItem.active {
-  background: linear-gradient(180deg, rgba(74,163,255,0.96), rgba(30,122,219,0.96));
-  border-color: rgba(166,216,255,0.95);
-  color: #fff;
+.glide__slide--active .tokenCard {
+  transform: translateY(-4px) scale(1.05);
+  opacity: 1;
+  color: rgba(20, 24, 38, 0.95);
 }
 
-/* When transcript is hidden in showcase mode, carousel can sit at bottom safely */
-#ui.uiHidden .carousel {
-  opacity: 0.95;
-}
-
-/* Transcript panel */
-.logPanel {
-  pointer-events: auto;
-  position: absolute;
-  left: 14px;
-  bottom: 14px;
-  width: min(760px, calc(100vw - 28px));
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.78);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.12);
-  border: 1px solid rgba(255,255,255,0.55);
-  overflow: hidden;
-  transition: opacity 140ms ease, transform 140ms ease;
-}
-
-.logHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 10px 12px;
-  border-bottom: 1px solid rgba(0,0,0,0.06);
-}
-
-.logTitle {
-  font-weight: 700;
-  font-size: 12px;
-  opacity: 0.85;
-}
-
-.logActions {
+.tokenCard {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  min-width: 88px;
+  height: 42px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.35));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    0 10px 26px rgba(30, 45, 90, 0.12);
+  font-weight: 600;
 }
 
-.iconBtn {
-  border: 1px solid rgba(0,0,0,0.10);
-  background: rgba(255,255,255,0.70);
-  border-radius: 10px;
-  padding: 6px 10px;
-  font-size: 12px;
+/* Hamburger + menu */
+.menuStack {
+  pointer-events: none;
+  position: fixed;
+  right: 18px;
+  bottom: 42px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  z-index: 6;
+}
+
+.hamburger {
+  pointer-events: auto;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  box-shadow: var(--glass-shadow);
+  display: grid;
+  gap: 5px;
+  padding: 12px;
+  cursor: pointer;
+  opacity: 1;
+  transition: opacity 200ms ease;
+}
+
+.hamburger span {
+  display: block;
+  height: 2px;
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(20, 24, 38, 0.8);
+}
+
+.hamburger.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.menu {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 18px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 180ms ease, transform 180ms ease;
+  pointer-events: none;
+}
+
+.menu.is-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.menuIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.6);
+  display: grid;
+  place-items: center;
   cursor: pointer;
 }
-.iconBtn:hover { transform: translateY(-1px); }
-.iconBtn:active { transform: translateY(0); }
 
-/* Pseudo console log body */
-.log {
-  padding: 10px 12px;
-  max-height: 180px;
-  overflow: auto;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+.menuIcon svg {
+  width: 20px;
+  height: 20px;
+  color: rgba(28, 32, 48, 0.8);
+}
+
+/* Sheets */
+.sheet {
+  pointer-events: auto;
+  position: fixed;
+  right: 18px;
+  bottom: 128px;
+  width: min(240px, 70vw);
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(18px) saturate(1.2);
+  -webkit-backdrop-filter: blur(18px) saturate(1.2);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 180ms ease, transform 180ms ease;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.sheet.is-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.sheetTitle {
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 6px;
+  color: rgba(22, 26, 40, 0.9);
+}
+
+.sheetBody {
   font-size: 12px;
-  line-height: 1.35;
-  background: rgba(0,0,0,0.03);
+  color: rgba(22, 26, 40, 0.7);
 }
 
-.logLine {
-  white-space: pre-wrap;
-  word-break: break-word;
-  padding: 2px 0;
-  opacity: 0.92;
-}
-.logLine.dim  { opacity: 0.70; }
-.logLine.warn { opacity: 0.92; }
-.logLine.err  { opacity: 0.95; }
-
-@media (max-width: 520px) {
-  .subtitle { display: none; }
-  .uiToggle { left: 10px; top: 10px; }
-
-  /* Remove header branding/copy on mobile (we'll rebrand later). */
-  .panelHeader { display: none; }
-
-  /* Transcript is moved into the bottom sheet Log tab; don't overlay it separately. */
-  .logPanel { display: none; }
-  .tabPanel .logPanel { display: block; }
-
-  /* Bigger tap targets (thumb-friendly) */
-  .tabBtn {
-    min-height: 44px;
-    padding: 10px 14px;
-    font-size: 14px;
+@media (max-width: 720px) {
+  .glassCarousel {
+    width: calc(100vw - 24px);
+    bottom: 24px;
   }
-  .compactBtn { width: 44px; padding: 10px 0; }
-  .iconBtn { min-height: 40px; padding: 10px 12px; font-size: 13px; }
 
-  /* Tab strip: scroll + snap so buttons can be big without wrapping */
-  .tabs {
-    scroll-snap-type: x mandatory;
+  .menuStack {
+    right: 12px;
+    bottom: 28px;
   }
-  .tabBtn { scroll-snap-align: start; }
 
-  .carousel {
-    left: 10px;
-    right: 10px;
-    bottom: 96px;
-    width: auto;
-    max-width: none;
-    transform: translate(0, 110%); /* override desktop centering translateX(-50%) */
+  .sheet {
+    right: 12px;
+    bottom: 120px;
   }
-  .carousel.open { transform: translate(0, 0); }
-  .carouselPeek { bottom: 10px; }
-  .carouselPeek.open { bottom: 176px; }
 }


### PR DESCRIPTION
### Motivation
- Remove the bulky legacy debug/control UI (tabs, transcript, wallet panels, toast, peek/legacy carousel) and replace it with a minimal iOS/glassmorphism overlay while leaving the Three.js scene, loaders, renderer, camera, lighting and postprocessing untouched.
- Provide a bottom GlideJS carousel that controls token loading and a small idle-driven hamburger menu with three placeholder sheets (Find, Share, Vibe). 
- Keep existing token-loading functionality (`loadFriendsies`) as the integration point and expose a `loadToken(tokenId)` wrapper for the carousel hook.

### Description
- Replaced the large legacy UI markup in `index.html` with a compact overlay: added GlideJS CSS/JS includes and new HTML for the bottom carousel (`#tokenGlide` / `#tokenSlides`), hamburger button and three small sheet panels (`#panel-find`, `#panel-share`, `#panel-vibe`). (See `index.html` changes.)
- Rewrote `style.css` to a glassmorphism design for the carousel, hamburger, menu and sheets and removed legacy UI styles so only the minimal overlay remains (new `style.css`).
- Removed legacy UI wiring in `main.js` (tabs, transcript, wallet lookup, toasts, large control handlers) and implemented a minimal UI controller that: initializes a GlideJS carousel (5 visible per view, center focused), debounces loads so a snapped token triggers `loadToken(tokenId)` after 150ms, and provides a hamburger/menu idle policy (hamburger auto-hides after 3000ms, returns after 10s inactivity on first interaction). Default token uses the app's existing default (kept existing default value). (See `main.js` changes.)
- Added `loadToken(tokenId)` as the integration hook which delegates to `loadFriendsies(tokenId)` without modifying Three.js initialization, lighting, renderer, camera parameters or loader configuration.

### Testing
- Quick static checks: ran `rg`/searches to verify legacy UI identifiers (panels, controls) were removed from `index.html` and replaced by the new overlay elements; those grep checks succeeded.
- Served the app locally with `python -m http.server 4173` and ran a Playwright script that opened `http://127.0.0.1:4173`, waited for the page to settle, and took a screenshot; the script completed and produced `artifacts/friendsies-ui.png` confirming the overlay renders.
- Verified repository state and committed the changes (`git commit`); commit succeeded.

All automated checks listed above succeeded. If you want, I can run further interactive tests (e.g., verify carousel snapping triggers `loadFriendsies` in a browser devtools console or wire the carousel default index to a different starting token).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986aec6dfdc832390fa294cb49a18cf)