### PR TITLE
Functional Find/Share/Vibe sheets, anchored positioning, and search flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         </div>
       </div>
 
-      <div class="menuStack">
+      <div id="menuStack" class="menuStack">
         <button id="hamburger" class="hamburger" type="button" aria-label="Menu">
           <span></span>
           <span></span>
@@ -65,19 +65,43 @@
             </svg>
           </button>
         </div>
-      </div>
 
-      <div id="panel-find" class="sheet" aria-hidden="true">
-        <div class="sheetTitle">Find</div>
-        <div class="sheetBody">Search sheet placeholder</div>
-      </div>
-      <div id="panel-share" class="sheet" aria-hidden="true">
-        <div class="sheetTitle">Share</div>
-        <div class="sheetBody">Share sheet placeholder</div>
-      </div>
-      <div id="panel-vibe" class="sheet" aria-hidden="true">
-        <div class="sheetTitle">Vibe</div>
-        <div class="sheetBody">Dev/settings placeholder</div>
+        <div id="panel-find" class="sheet" aria-hidden="true">
+          <div class="sheetBody">
+            <input
+              id="searchInput"
+              class="searchInput"
+              type="text"
+              placeholder="Token #, ENS, or wallet"
+              autocomplete="off"
+              inputmode="search"
+            />
+            <button
+              id="resetCollectionBtn"
+              class="sheetAction viewAllChip"
+              type="button"
+              aria-hidden="true"
+            >
+              View all
+            </button>
+            <div id="searchResults" class="searchResults"></div>
+          </div>
+        </div>
+        <div id="panel-share" class="sheet" aria-hidden="true">
+          <div class="sheetBody">
+            <button id="copyLinkBtn" class="sheetAction" type="button">Copy link</button>
+            <button id="downloadGlbBtn" class="sheetAction" type="button">Download .glb</button>
+          </div>
+        </div>
+        <div id="panel-vibe" class="sheet" aria-hidden="true">
+          <div class="sheetBody">
+            <button class="sheetAction" data-preset="Cinematic" type="button">Cinematic</button>
+            <button class="sheetAction" data-preset="Punchy Toybox" type="button">
+              Punchy Toybox
+            </button>
+            <button class="sheetAction" data-preset="Soft Pastel" type="button">Soft Pastel</button>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@ body {
     "Apple Color Emoji", "Segoe UI Emoji";
 }
 
+html {
+  overscroll-behavior: none;
+}
+
 canvas {
   display: block;
   width: 100vw;
@@ -92,6 +96,15 @@ canvas {
   align-items: flex-end;
   gap: 12px;
   z-index: 6;
+  --sheet-offset: 0px;
+}
+
+.menuStack[data-active-panel="share"] {
+  --sheet-offset: -50px;
+}
+
+.menuStack[data-active-panel="find"] {
+  --sheet-offset: -100px;
 }
 
 .hamburger {
@@ -109,7 +122,7 @@ canvas {
   padding: 18px;
   cursor: pointer;
   opacity: 1;
-  transition: opacity 200ms ease;
+  transition: opacity 350ms ease, transform 200ms ease;
 }
 
 .hamburger span {
@@ -122,6 +135,7 @@ canvas {
 
 .hamburger.is-hidden {
   opacity: 0;
+  transform: scale(0.92);
   pointer-events: none;
 }
 
@@ -169,9 +183,9 @@ canvas {
 /* Sheets */
 .sheet {
   pointer-events: auto;
-  position: fixed;
-  right: 18px;
-  bottom: 128px;
+  position: absolute;
+  right: calc(100% + 12px);
+  bottom: 0;
   width: min(240px, 70vw);
   padding: 14px 16px;
   border-radius: 18px;
@@ -181,28 +195,83 @@ canvas {
   border: 1px solid var(--glass-border);
   box-shadow: var(--glass-shadow);
   opacity: 0;
-  transform: translateY(10px);
+  transform: translateY(calc(var(--sheet-offset) + 10px));
   transition: opacity 180ms ease, transform 180ms ease;
   pointer-events: none;
-  z-index: 5;
+  z-index: 7;
 }
 
 .sheet.is-open {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(var(--sheet-offset));
   pointer-events: auto;
-}
-
-.sheetTitle {
-  font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 6px;
-  color: rgba(22, 26, 40, 0.9);
 }
 
 .sheetBody {
   font-size: 12px;
   color: rgba(22, 26, 40, 0.7);
+}
+
+.sheetAction {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  color: rgba(22, 26, 40, 0.85);
+}
+
+.sheetAction + .sheetAction {
+  margin-top: 6px;
+}
+
+.sheetAction:hover {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.sheetAction.is-active {
+  background: rgba(22, 26, 40, 0.08);
+  font-weight: 600;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.4);
+  font-size: 14px;
+  outline: none;
+  color: rgba(22, 26, 40, 0.9);
+}
+
+.searchInput::placeholder {
+  color: rgba(22, 26, 40, 0.4);
+}
+
+.searchInput:focus {
+  border-color: rgba(22, 26, 40, 0.2);
+}
+
+.searchResults {
+  margin-top: 8px;
+  font-size: 12px;
+  color: rgba(22, 26, 40, 0.6);
+}
+
+.viewAllChip {
+  margin-top: 8px;
+  text-align: center;
+  display: none;
+}
+
+.viewAllChip.is-visible {
+  display: block;
 }
 
 @media (max-width: 720px) {
@@ -212,12 +281,36 @@ canvas {
   }
 
   .menuStack {
-    right: max(22px, calc(env(safe-area-inset-right) + 10px));
-    bottom: max(24px, calc(env(safe-area-inset-bottom) + 10px));
+    right: max(16px, calc(env(safe-area-inset-right) + 8px));
+    bottom: auto;
+    top: max(20px, calc(env(safe-area-inset-top) + 12px));
+    --sheet-offset: 0px;
   }
 
   .sheet {
-    right: 12px;
-    bottom: 120px;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    border-radius: 18px 18px 0 0;
+    max-height: 60vh;
+    overflow-y: auto;
+    transform: translateY(10px);
+  }
+
+  .sheet.is-open {
+    transform: translateY(0);
+  }
+
+  .menuIcon {
+    width: 44px;
+    height: 44px;
+  }
+
+  .hamburger {
+    width: 66px;
+    height: 66px;
+    padding: 16px;
   }
 }


### PR DESCRIPTION
### Motivation

- Replace dummy sheet placeholders with usable UI and make sheets visually anchor to the menu icons so the UI feels spatially consistent and mobile-friendly.
- Provide an in-app search for token IDs, ENS names, and wallet addresses so users can navigate to tokens/wallets without crafting a URL.
- Add share/download and look-preset actions and polish hamburger auto-hide and mobile touch targets to improve UX.

### Description

- Moved the three `.sheet` elements inside the `.menuStack` and added `id="menuStack"` to enable data-driven positioning and alignment via `data-active-panel` (changes in `index.html` and `main.js`).
- Replaced placeholder sheet content with: a Find sheet containing `#searchInput`, `#searchResults`, and a conditional `View all` chip; a Share sheet with `Copy link` and `Download .glb` buttons; and a Vibe sheet with preset buttons wired to `applyLookPreset` (changes in `index.html`, `style.css`, and `main.js`).
- Implemented search logic in `main.js` to detect bare token numbers, ENS names (`.eth`), and full 0x addresses and to navigate accordingly by updating the carousel, loading tokens, and pushing a URL slug; added auto-focus when opening Find and a `resetToFullCollection()` flow.
- Wired Share actions to `navigator.clipboard.writeText` and existing `downloadRigGlb()` and wired Vibe preset buttons to `applyLookPreset` with visual active state; increased `HAMBURGER_HIDE_MS` from `3000` to `4000` and added subtle fade/scale animation.
- Reworked sheet positioning and mobile behavior in `style.css`: sheets are now absolutely anchored to `.menuStack` on desktop and become full-width bottom-sheets on small screens, adjusted touch target sizes to meet minimum recommendations, and added `overscroll-behavior: none` to prevent iOS white flash.

### Testing

- Served the static site locally using `python -m http.server 8000`, which started successfully for a local smoke check; no full automated unit tests exist for this static site.
- Attempted an automated Playwright smoke script to open the page, click the hamburger, open the Find panel, and capture a screenshot, but the headless browser runs timed out or crashed in this environment so the Playwright UI check failed; no UI screenshot was produced.
- Performed automated code inspection commands (`rg`, file diffs) to verify the expected files were modified and that new handlers (`handleSearch`, `navigateToWallet`, share/preset listeners) are present; these static validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986d13d8864832395586fc1034ea786)