### PR TITLE
Show 3 tokens in carousel on smallest mobile viewports

### DIFF
--- a/main.js
+++ b/main.js
@@ -2389,6 +2389,11 @@ function initCarousel(startTokenId = DEFAULT_TOKEN_ID) {
     perView: 5,
     focusAt: "center",
     gap: 12,
+    breakpoints: {
+      480: {
+        perView: 3
+      }
+    },
     rewind: false,
     bound: true
   });


### PR DESCRIPTION
### Motivation
- Reduce clutter and overlapping token cards on very small mobile screens by showing fewer carousel items.

### Description
- Add a `breakpoints` option to the Glide initialization in `main.js` to set `perView: 3` at the `480`px breakpoint so the carousel displays three tokens on small viewports.

### Testing
- Started a local server with `python -m http.server` and ran a Playwright script to capture a screenshot at `375x667`, which completed successfully and produced `artifacts/token-carousel-mobile.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874415fe1c83239199793d399328e4)