### PR TITLE
Fix entry lookup indexing and add token #5 sanity check

### DIFF
--- a/main.js
+++ b/main.js
@@ -1936,8 +1936,8 @@ function getSelectedAnimUrl() {
 function getEntryById(id) {
   if (!allFriendsies) return null;
   return (
-    allFriendsies[id] ||
     allFriendsies[id - 1] ||
+    allFriendsies[id] ||
     allFriendsies.find?.((x) => Number(x?.token_id) === id) ||
     allFriendsies.find?.((x) => Number(x?.id) === id) ||
     null
@@ -1961,6 +1961,13 @@ async function loadFriendsies(id) {
   if (!entry) {
     restoreAvatarVisibility();
     return setStatus(`not found: #${id}`);
+  }
+  if (id === 5) {
+    const tokenId = Number(entry?.token_id ?? entry?.id);
+    console.assert(
+      tokenId === 5,
+      `Sanity check failed: expected token #5, got #${tokenId}`
+    );
   }
 
   const traits = entry.attributes || [];


### PR DESCRIPTION
### Motivation
- Fix off-by-one lookup in `getEntryById` so the 0-based array index is preferred over raw `id` indexing to avoid returning the wrong entry. 
- Add a quick runtime sanity check to detect if loading token #5 returns the incorrect token entry.

### Description
- Reordered the lookup in `getEntryById` to check `allFriendsies[id - 1]` before `allFriendsies[id]` and retain the `token_id`/`id` `.find` fallbacks. 
- Added a runtime assertion in `loadFriendsies` that, when `id === 5`, computes `Number(entry?.token_id ?? entry?.id)` and calls `console.assert` to verify it equals `5`.
- Kept existing `.find` fallbacks to still support objects keyed by `token_id`/`id`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b182cfa083239825b12ab5f73a11)