### PR TITLE
Fix Friendsies entry lookup index order and add token #5 sanity check

### DIFF
--- a/main.js
+++ b/main.js
@@ -1936,8 +1936,8 @@ function getSelectedAnimUrl() {
 function getEntryById(id) {
   if (!allFriendsies) return null;
   return (
-    allFriendsies[id] ||
     allFriendsies[id - 1] ||
+    allFriendsies[id] ||
     allFriendsies.find?.((x) => Number(x?.token_id) === id) ||
     allFriendsies.find?.((x) => Number(x?.id) === id) ||
     null
@@ -2723,6 +2723,16 @@ window.addEventListener("pointerdown", (event) => {
     .then((r) => r.json())
     .then((data) => {
       allFriendsies = data;
+      const sanityEntry = getEntryById(5);
+      const sanityTokenId = Number(sanityEntry?.token_id ?? sanityEntry?.id);
+      if (sanityEntry && sanityTokenId === 5) {
+        logLine("✅ Sanity check: token #5 resolves to token_id 5", "dim");
+      } else {
+        logLine(
+          `⚠️ Sanity check: token #5 resolved to ${Number.isFinite(sanityTokenId) ? sanityTokenId : "unknown"}`,
+          "warn"
+        );
+      }
       setStatus("ready ✅");
       if (pendingTokenId) {
         debounceTokenLoad(pendingTokenId);


### PR DESCRIPTION
### Motivation
- Prevent off-by-one mismatches when resolving metadata entries so `getEntryById` returns the intended token rather than an adjacent item.
- Provide a quick runtime verification that token lookups resolve correctly after metadata is fetched.

### Description
- Change `getEntryById(id)` to prefer the 0-based array lookup `allFriendsies[id - 1]` before the raw index `allFriendsies[id]` to avoid incorrect resolution for 1-based token IDs.
- Add a sanity check after loading `METADATA_URL` that calls `getEntryById(5)` and logs a success message if the resolved `token_id` (or `id`) equals `5`, otherwise logs a warning with the resolved value.
- All changes are in `main.js` and only affect entry resolution and post-fetch logging.

### Testing
- No automated tests were run as part of this change.
- A runtime sanity check was added that will log whether token `#5` resolves to `token_id` `5` when metadata is fetched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b2fda9bc8323b4ac8763b4f17cdc)