### PR TITLE
Fix carousel default token selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -2477,14 +2477,13 @@ function bindCarouselListeners() {
 
 function setActiveCarouselIndex(index, { loadToken: shouldLoad = true } = {}) {
   if (!Number.isFinite(index) || !ui.slides) return;
-  if (activeCarouselIndex === index) return;
+  const tokenId = carouselTokenIds[index];
   const prev = ui.slides.querySelector(`[data-index=\"${activeCarouselIndex}\"]`);
-  if (prev) prev.classList.remove("is-active");
   const next = ui.slides.querySelector(`[data-index=\"${index}\"]`);
+  if (prev && prev !== next) prev.classList.remove("is-active");
   if (next) next.classList.add("is-active");
   activeCarouselIndex = index;
-  const tokenId = carouselTokenIds[index];
-  if (shouldLoad && tokenId) {
+  if (shouldLoad && tokenId && tokenId !== lastLoadedTokenId) {
     requestTokenLoad(tokenId);
   }
 }


### PR DESCRIPTION
### Motivation
- Resolve a case where the carousel could not select the default token because `setActiveCarouselIndex` returned early and did not refresh the active slide or retrigger loading.

### Description
- Modify `setActiveCarouselIndex` to always locate the `prev` and `next` slide elements, only remove the `is-active` class when they differ, update `activeCarouselIndex`, and call `requestTokenLoad` only when the selected token differs from `lastLoadedTokenId`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b40f1dd483238216baa326d298e0)