### PR TITLE
Center carousel cards, increase spacing, and reduce carousel width

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,7 +58,7 @@ canvas {
   --text-secondary: rgba(22, 26, 40, 0.55);
   --text-muted: rgba(22, 26, 40, 0.35);
   --card-width: 120px;
-  --card-gap: 14px;
+  --card-gap: 18px;
 }
 
 /* Carousel */
@@ -68,7 +68,7 @@ canvas {
   left: 50%;
   bottom: 28px;
   transform: translateX(-50%);
-  width: min(720px, calc(100vw - 32px));
+  width: min(560px, calc(100vw - 48px));
   padding: 12px 18px 16px;
   border-radius: var(--radius-lg);
   background: rgba(255, 255, 255, 0.45);
@@ -102,6 +102,7 @@ canvas {
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
   padding-bottom: 6px;
+  padding-inline: 8px;
   scrollbar-width: none;
   transform: translateZ(0);
   -webkit-overflow-scrolling: touch;
@@ -115,9 +116,11 @@ canvas {
   list-style: none;
   display: flex;
   align-items: stretch;
+  justify-content: center;
   gap: var(--card-gap);
-  padding: 4px 2px 8px;
-  margin: 0;
+  padding: 4px 10px 8px;
+  margin: 0 auto;
+  min-width: 100%;
 }
 
 .tokenSlide {
@@ -500,7 +503,7 @@ canvas {
 
 @media (max-width: 720px) {
   .glassCarousel {
-    width: calc(100vw - 24px);
+    width: min(520px, calc(100vw - 32px));
     bottom: 24px;
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
@@ -508,7 +511,7 @@ canvas {
 
   :root {
     --card-width: 104px;
-    --card-gap: 10px;
+    --card-gap: 12px;
   }
 
   .sheet {


### PR DESCRIPTION
### Motivation
- Center carousel slides inside the track so cards appear visually centered within the glass panel.
- Improve spacing between cards for clearer visual alignment and touch affordance.
- Reduce the carousel element width so it no longer spans the full layout width and better aligns with surrounding UI.

### Description
- Increased `--card-gap` from `14px` to `18px` (and mobile from `10px` to `12px`) to give cards more breathing room.
- Reduced `.glassCarousel` width from `min(720px, calc(100vw - 32px))` to `min(560px, calc(100vw - 48px))` and adjusted the mobile breakpoint to `min(520px, calc(100vw - 32px))` to tighten the layout footprint.
- Added `padding-inline: 8px` to `.carouselViewport` and centered the track with `.tokenTrack { justify-content: center; margin: 0 auto; min-width: 100%; padding: 4px 10px 8px; }` so slides are centered and consistent across viewport sizes.
- All changes are CSS-only in `style.css`, no JS changes were required.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a rendering screenshot via a Playwright script which completed successfully and produced `artifacts/carousel-update.png`.
- Visual verification was performed from the generated screenshot and the layout change appears as intended (no automated unit tests were required for CSS-only edits).
- Changes were committed to the repository (`git commit`) after verification and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987e3a963388323b25e969190349235)