### PR TITLE
Tighten carousel hide timing and prevent mobile input zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <title>fRiENDSiES Toy Box</title>
     <link rel="stylesheet" href="/style.css?v=2026-02-03c" />
 

--- a/main.js
+++ b/main.js
@@ -2153,8 +2153,8 @@ async function playAnimUrl(url, loadIdGuard = currentLoadId) {
 // ----------------------------
 // Minimal UI: idle hamburger + menu + carousel
 // ----------------------------
-const HAMBURGER_HIDE_MS = 4000;
-const CAROUSEL_HIDE_MS = 5000;
+const HAMBURGER_HIDE_MS = 1000;
+const CAROUSEL_HIDE_MS = 1000;
 const IDLE_TIMEOUT_MS = 10000;
 let hamburgerTimer = null;
 let carouselHideTimer = null;

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ body {
   background: #ffffff;
   font-family: "SF Pro Display", "Inter", ui-sans-serif, system-ui, -apple-system,
     "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  -webkit-text-size-adjust: 100%;
 }
 
 html {
@@ -475,7 +476,7 @@ canvas {
   border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.4);
-  font-size: 14px;
+  font-size: 16px;
   outline: none;
   color: var(--text-primary);
   transition: border-color 150ms ease, box-shadow 150ms ease;


### PR DESCRIPTION
### Motivation
- Reduce perceived UI clutter by hiding the hamburger and carousel faster (1s) after inactivity.
- Avoid mobile viewport zoom/aspect changes when focusing the search field so the app stays full-screen on mobile.
- Prevent iOS auto-zoom on input focus by increasing input font size and disabling text-size auto-adjust.

### Description
- Changed `HAMBURGER_HIDE_MS` and `CAROUSEL_HIDE_MS` from `4000/5000` to `1000` in `main.js` to shorten auto-hide delays.
- Locked mobile scaling by adding `maximum-scale=1, user-scalable=no` to the `<meta name="viewport">` in `index.html`.
- Added `-webkit-text-size-adjust: 100%` to the base styles and increased `.searchInput` font-size from `14px` to `16px` in `style.css` to reduce focus zoom.

### Testing
- Started a local static server with `python -m http.server 8000`, which launched successfully.
- Attempted automated mobile interaction via Playwright to click the hamburger, open the find sheet, type into `#searchInput`, and take a screenshot, but the Playwright run timed out/failed.
- No additional automated unit tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989448ee9e8832381253406cf6f9987)