### PR TITLE
Auto-hide carousel after token snaps into place

### DIFF
--- a/main.js
+++ b/main.js
@@ -2296,11 +2296,11 @@ function showHamburger() {
   }, HAMBURGER_HIDE_MS);
 }
 
-function showCarousel() {
+function showCarousel({ force = false } = {}) {
   if (!ui.carousel) return;
   ui.carousel.classList.remove("is-hidden");
   if (carouselHideTimer) clearTimeout(carouselHideTimer);
-  if (carouselHovered || isDragging || carouselScrolling) return;
+  if (!force && (carouselHovered || isDragging || carouselScrolling)) return;
   carouselHideTimer = setTimeout(() => {
     ui.carousel?.classList.add("is-hidden");
   }, CAROUSEL_HIDE_MS);
@@ -2777,7 +2777,7 @@ function bindCarouselListeners() {
     const scrollLeft = ui.carouselViewport.scrollLeft;
     const centerIndex = scrollLeftToIndex(scrollLeft);
     setActiveCarouselIndex(centerIndex, { forceLoad: true });
-    showCarousel();
+    showCarousel({ force: true });
   };
 
   if ("onscrollend" in window) {


### PR DESCRIPTION
When scrolling settles, force-start the 1-second hide timer even if the pointer is still hovering over the carousel. This prevents the carousel from staying open indefinitely after selecting a new token.

https://claude.ai/code/session_01PJxSeXkKedmVREkJUPmgS6