### PR TITLE
Add carousel pin toggle for persistent visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,20 @@
 
   <body>
     <div id="ui" class="ui">
-      <div id="tokenCarousel" class="glassCarousel" aria-label="Token picker">
-        <div id="carouselViewport" class="carouselViewport" role="listbox">
-          <div id="spacerLeft" class="carouselSpacer"></div>
-          <ul class="tokenTrack" id="tokenSlides"></ul>
-          <div id="spacerRight" class="carouselSpacer"></div>
+      <div id="carouselRegion" class="carouselRegion">
+        <button
+          id="carouselToggle"
+          class="carouselToggle is-hidden"
+          type="button"
+          aria-label="Pin carousel open"
+          aria-pressed="false"
+        >&#9729;</button>
+        <div id="tokenCarousel" class="glassCarousel is-hidden" aria-label="Token picker">
+          <div id="carouselViewport" class="carouselViewport" role="listbox">
+            <div id="spacerLeft" class="carouselSpacer"></div>
+            <ul class="tokenTrack" id="tokenSlides"></ul>
+            <div id="spacerRight" class="carouselSpacer"></div>
+          </div>
         </div>
       </div>
 

--- a/main.js
+++ b/main.js
@@ -415,6 +415,8 @@ function applyLookPreset(name) {
 
 const uiRoot = document.getElementById("ui");
 const ui = {
+  carouselRegion: document.getElementById("carouselRegion"),
+  carouselToggle: document.getElementById("carouselToggle"),
   carousel: document.getElementById("tokenCarousel"),
   slides: document.getElementById("tokenSlides"),
   carouselViewport: document.getElementById("carouselViewport"),
@@ -2166,6 +2168,8 @@ let orbitReleaseTimer = null;
 let carouselHovered = false;
 let carouselScrolling = false;
 let hamburgerHovered = false;
+let carouselPinned = false;
+let toggleHideTimer = null;
 
 let carouselTokenIds = [...DEFAULT_TOKEN_IDS];
 let carouselTokenIdSet = new Set(carouselTokenIds);
@@ -2290,6 +2294,8 @@ function showHamburger() {
   if (!ui.hamburger) return;
   ui.hamburger.classList.remove("is-hidden");
   if (hamburgerTimer) clearTimeout(hamburgerTimer);
+  // Toggle follows hamburger visibility (unless carousel is pinned)
+  showToggle(false);
   if (menuOpen || hamburgerHovered) return;
   hamburgerTimer = setTimeout(() => {
     ui.hamburger?.classList.add("is-hidden");
@@ -2300,10 +2306,51 @@ function showCarousel() {
   if (!ui.carousel) return;
   ui.carousel.classList.remove("is-hidden");
   if (carouselHideTimer) clearTimeout(carouselHideTimer);
+
+  // Pinned — carousel stays open, toggle stays visible alongside it
+  if (carouselPinned) {
+    showToggle(true);
+    return;
+  }
+
   if (carouselHovered || isDragging || carouselScrolling) return;
   carouselHideTimer = setTimeout(() => {
     ui.carousel?.classList.add("is-hidden");
   }, CAROUSEL_HIDE_MS);
+}
+
+function showToggle(persistent) {
+  if (!ui.carouselToggle) return;
+  ui.carouselToggle.classList.remove("is-hidden");
+  if (toggleHideTimer) clearTimeout(toggleHideTimer);
+  // If persistent (pinned) or carousel is hovered, don't auto-hide
+  if (persistent || carouselPinned || carouselHovered) return;
+  // Otherwise follow hamburger timing
+  if (menuOpen || hamburgerHovered) return;
+  toggleHideTimer = setTimeout(() => {
+    ui.carouselToggle?.classList.add("is-hidden");
+  }, HAMBURGER_HIDE_MS);
+}
+
+function setCarouselPinned(pinned) {
+  carouselPinned = !!pinned;
+  if (!ui.carouselToggle) return;
+  ui.carouselToggle.classList.toggle("is-pinned", carouselPinned);
+  ui.carouselToggle.setAttribute("aria-pressed", String(carouselPinned));
+  ui.carouselToggle.setAttribute(
+    "aria-label",
+    carouselPinned ? "Unpin carousel" : "Pin carousel open"
+  );
+
+  if (carouselPinned) {
+    // Pin — show carousel and keep toggle visible
+    showCarousel();
+    showToggle(true);
+  } else {
+    // Unpin — let normal auto-hide resume
+    showCarousel();
+    showToggle(false);
+  }
 }
 
 function scheduleIdleTimer() {
@@ -2949,13 +2996,19 @@ ui.hamburger?.addEventListener("pointerleave", () => {
   showHamburger();
 });
 
+ui.carouselToggle?.addEventListener("click", () => {
+  setCarouselPinned(!carouselPinned);
+});
+
 ui.carousel?.addEventListener("pointerenter", () => {
   carouselHovered = true;
   showCarousel();
+  showToggle(false);
 });
 ui.carousel?.addEventListener("pointerleave", () => {
   carouselHovered = false;
   showCarousel();
+  showToggle(false);
 });
 
 controls?.addEventListener("end", () => {

--- a/style.css
+++ b/style.css
@@ -62,21 +62,81 @@ canvas {
   --card-gap: 14px;
 }
 
-/* Carousel */
-.glassCarousel {
-  pointer-events: auto;
+/* Carousel region (wrapper for toggle + carousel) */
+.carouselRegion {
+  --toggle-offset: 12px; /* gap between toggle and carousel top */
+  pointer-events: none;
   position: fixed;
   left: 50%;
   bottom: 28px;
   transform: translateX(-50%);
   width: min(720px, calc(100vw - 32px));
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Toggle button */
+.carouselToggle {
+  pointer-events: auto;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-circle);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.42);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  box-shadow: 0 4px 18px rgba(14, 20, 42, 0.10);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  margin-bottom: var(--toggle-offset);
+  opacity: 1;
+  transition: opacity 350ms ease,
+    transform 400ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    background 200ms ease,
+    box-shadow 200ms ease;
+  will-change: transform, opacity;
+  flex-shrink: 0;
+}
+
+.carouselToggle:hover {
+  background: rgba(255, 255, 255, 0.65);
+  transform: scale(1.10);
+  box-shadow: 0 6px 22px rgba(14, 20, 42, 0.14);
+}
+
+.carouselToggle:active {
+  transform: scale(0.95);
+}
+
+.carouselToggle.is-hidden {
+  opacity: 0;
+  transform: scale(0.7) translateY(8px);
+  pointer-events: none;
+}
+
+/* Pinned state — elevated glass, subtle glow */
+.carouselToggle.is-pinned {
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 0 16px rgba(255, 255, 255, 0.4),
+    0 6px 24px rgba(14, 20, 42, 0.12);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+/* Carousel */
+.glassCarousel {
+  pointer-events: auto;
+  width: 100%;
   padding: 12px 18px 16px;
   border-radius: var(--radius-lg);
   background: rgba(255, 255, 255, 0.45);
   backdrop-filter: var(--glass-blur);
   -webkit-backdrop-filter: var(--glass-blur);
   box-shadow: var(--glass-shadow);
-  z-index: 5;
   transition: opacity 400ms ease,
     transform 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
   will-change: transform, opacity;
@@ -84,7 +144,7 @@ canvas {
 
 .glassCarousel.is-hidden {
   opacity: 0;
-  transform: translateX(-50%) translateY(16px);
+  transform: translateY(16px);
   /* Keep pointer-events: auto so the carousel can receive scroll/drag
      even while visually hidden — interaction will trigger showCarousel(). */
 }
@@ -507,9 +567,12 @@ canvas {
 }
 
 @media (max-width: 720px) {
-  .glassCarousel {
+  .carouselRegion {
     width: calc(100vw - 24px);
     bottom: 24px;
+  }
+
+  .glassCarousel {
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
   }
@@ -517,6 +580,12 @@ canvas {
   :root {
     --card-width: 104px;
     --card-gap: 10px;
+  }
+
+  .carouselToggle {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
   }
 
   .sheet {
@@ -540,7 +609,8 @@ canvas {
 @media (prefers-reduced-motion: reduce) {
   .tokenSlide,
   .tokenCard,
-  .tokenImage {
+  .tokenImage,
+  .carouselToggle {
     transition: none !important;
     animation: none !important;
   }


### PR DESCRIPTION
## Summary
Adds a pin toggle button that allows users to keep the token carousel persistently visible. When pinned, the carousel and toggle remain on screen; when unpinned, they follow the normal auto-hide behavior.

## Key Changes
- **New UI structure**: Wrapped carousel in a `carouselRegion` container that holds both the toggle button and carousel
- **Toggle button**: Added a 40px circular button with glass morphism styling that displays a pin icon (☃)
  - Shows/hides with the carousel using the same auto-hide logic
  - Displays an `is-pinned` state with elevated glass and subtle glow effect
  - Updates `aria-pressed` and `aria-label` to reflect pinned state
- **Pinned state logic**: 
  - When pinned: carousel and toggle stay visible, auto-hide timers are bypassed
  - When unpinned: normal auto-hide behavior resumes
  - Toggle visibility follows hamburger menu visibility unless carousel is pinned
- **State management**: Added `carouselPinned` flag and `toggleHideTimer` to track pin state and manage toggle visibility
- **Event handling**: Toggle click triggers `setCarouselPinned()` to toggle the pinned state
- **Styling**: 
  - Toggle has hover/active states with scale transforms
  - Hidden state uses opacity and scale-down animation
  - Responsive sizing for mobile (36px on small screens)
  - Respects `prefers-reduced-motion` by disabling transitions

## Implementation Details
- The toggle button is initially hidden (`is-hidden` class) and only appears when the carousel is shown
- When carousel is pinned, `showToggle(true)` is called with the `persistent` flag to prevent auto-hide
- The toggle inherits the same glass morphism design language as the carousel for visual cohesion
- Carousel transform simplified from `translateX(-50%) translateY(16px)` to just `translateY(16px)` since the region container now handles horizontal centering

https://claude.ai/code/session_01FReKBC3JQDoPPMgNbA2sV8