### PR TITLE
Remove hardcoded camera target position in loadFriendsies

### DIFF
--- a/main.js
+++ b/main.js
@@ -2102,7 +2102,6 @@ async function loadFriendsies(id) {
   avatarGroup.visible = true;
 
   applyLookControls();
-  controls.target.set(0, 0.92, 0);
 
   setStatus(
     `loaded #${id} ✅ parts:${loadedParts.length} bones:${bodySkeleton.bones.length} faceOverlays:${faceOverlayMeshes.length}`


### PR DESCRIPTION
## Summary
Removed a hardcoded camera target position that was being set during the friends loading process. This allows the camera controls to maintain their existing target position rather than forcing it to a specific coordinate.

## Changes
- Removed `controls.target.set(0, 0.92, 0);` from the `loadFriendsies()` function

## Details
The hardcoded camera target was overriding the camera's target position every time a friend was loaded. By removing this line, the camera behavior becomes more flexible and respects the existing control state, likely improving the user experience when loading multiple friends or when custom camera positions have been set.

https://claude.ai/code/session_012cRdNvhuGAA6U7JBQ63fFH