### PR TITLE
Fix carousel dismiss behavior to respect user intent

### DIFF
--- a/main.js
+++ b/main.js
@@ -2168,6 +2168,7 @@ let carouselHovered = false;
 let carouselScrolling = false;
 let hamburgerHovered = false;
 let carouselPinned = false;
+let carouselDismissed = false;
 let toggleHideTimer = null;
 
 let carouselTokenIds = [...DEFAULT_TOKEN_IDS];
@@ -2303,6 +2304,10 @@ function showHamburger() {
 
 function showCarousel() {
   if (!ui.carousel) return;
+
+  // User explicitly dismissed the carousel via toggle — keep it hidden
+  if (carouselDismissed) return;
+
   ui.carousel.classList.remove("is-hidden");
   if (carouselHideTimer) clearTimeout(carouselHideTimer);
 
@@ -2333,6 +2338,7 @@ function showToggle(persistent) {
 
 function setCarouselPinned(pinned) {
   carouselPinned = !!pinned;
+  carouselDismissed = !carouselPinned;
   if (!ui.carouselToggle) return;
   ui.carouselToggle.classList.toggle("is-pinned", carouselPinned);
   ui.carouselToggle.setAttribute("aria-pressed", String(carouselPinned));
@@ -2346,8 +2352,9 @@ function setCarouselPinned(pinned) {
     showCarousel();
     showToggle(true);
   } else {
-    // Unpin — let normal auto-hide resume
-    showCarousel();
+    // Dismiss — immediately hide carousel, keep toggle visible
+    if (carouselHideTimer) clearTimeout(carouselHideTimer);
+    ui.carousel?.classList.add("is-hidden");
     showToggle(false);
   }
 }

--- a/main.js
+++ b/main.js
@@ -2327,8 +2327,8 @@ function showToggle(persistent) {
   if (!ui.carouselToggle) return;
   ui.carouselToggle.classList.remove("is-hidden");
   if (toggleHideTimer) clearTimeout(toggleHideTimer);
-  // If persistent (pinned) or carousel is hovered, don't auto-hide
-  if (persistent || carouselPinned || carouselHovered) return;
+  // If persistent (pinned), dismissed, or carousel is hovered, don't auto-hide
+  if (persistent || carouselPinned || carouselDismissed || carouselHovered) return;
   // Otherwise follow hamburger timing
   if (menuOpen || hamburgerHovered) return;
   toggleHideTimer = setTimeout(() => {
@@ -2349,13 +2349,15 @@ function setCarouselPinned(pinned) {
 
   if (carouselPinned) {
     // Pin — show carousel and keep toggle visible
+    ui.carouselRegion?.classList.remove("is-dismissed");
     showCarousel();
     showToggle(true);
   } else {
-    // Dismiss — immediately hide carousel, keep toggle visible
+    // Dismiss — immediately hide carousel, slide toggle to bottom
     if (carouselHideTimer) clearTimeout(carouselHideTimer);
     ui.carousel?.classList.add("is-hidden");
-    showToggle(false);
+    ui.carouselRegion?.classList.add("is-dismissed");
+    showToggle(true);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -75,6 +75,20 @@ canvas {
   display: flex;
   flex-direction: column;
   align-items: center;
+  transition: bottom 400ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Dismissed — toggle slides to bottom edge, carousel collapses */
+.carouselRegion.is-dismissed {
+  bottom: 8px;
+}
+
+.carouselRegion.is-dismissed .glassCarousel {
+  display: none;
+}
+
+.carouselRegion.is-dismissed .carouselToggle {
+  margin-bottom: 0;
 }
 
 /* Toggle button */


### PR DESCRIPTION
## Summary
This PR fixes the carousel toggle behavior to properly respect when a user explicitly dismisses the carousel. Previously, the carousel would reappear even after being dismissed by the user.

## Key Changes
- Added `carouselDismissed` state variable to track explicit user dismissals
- Modified `showCarousel()` to check the dismissed state and skip showing if the user has dismissed it
- Updated `setCarouselPinned()` to set `carouselDismissed` based on pinned state (dismissed when unpinned)
- Changed unpin behavior to immediately hide the carousel instead of showing it, while keeping the toggle visible for re-engagement

## Implementation Details
- When the carousel is pinned, `carouselDismissed` is set to `false`, allowing normal show/hide behavior
- When unpinned (dismissed), `carouselDismissed` is set to `true`, preventing `showCarousel()` from displaying it
- The carousel is immediately hidden on dismiss with any pending hide timers cleared
- The toggle remains visible after dismissal so users can re-pin the carousel if desired

https://claude.ai/code/session_01X9mWNM2MiFJAniymCseMZ5