### PR TITLE
feat: redesign welcome modal as premium studio onboarding card

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,21 +187,81 @@
       </div>
 
       <div id="onboarding" class="onboarding" aria-hidden="true">
-        <div class="onboardingCard" role="dialog" aria-modal="true" aria-labelledby="onboardingTitle">
-          <h2 id="onboardingTitle">Welcome to fRiENEMiES Studio</h2>
-          <p class="onboardingLead">Better Than Friends. Let’s be fRiENEMiES 😈</p>
-          <p class="onboardingCopy">Community-built studio for viewing, previewing animations, and exporting rig-ready .glb assets.</p>
-          <div class="quickstartTitle">Quickstart</div>
-          <ol class="onboardingSteps">
-            <li>Enter a Token ID or Wallet / ENS</li>
-            <li>Browse, rotate, and preview</li>
-            <li>Export clean .glb files</li>
-          </ol>
-          <p class="onboardingFinePrint">No wallet connect required.</p>
-          <div class="onboardingActions">
-            <button id="onboardingLearnMore" class="sheetAction" type="button">Learn more</button>
-            <button id="onboardingDismiss" class="sheetAction" type="button">Got it</button>
+        <div class="onboardingCard" role="dialog" aria-modal="true" aria-labelledby="onboardingTitle" aria-describedby="onboardingBody">
+
+          <!-- Branded header band -->
+          <div class="onboardingHeader">
+            <h2 id="onboardingTitle" class="onboardingTitle">Welcome to fRiENEMiES Studio</h2>
+            <p class="onboardingSubtitle">Load &bull; Preview &bull; Export</p>
           </div>
+
+          <!-- Body content -->
+          <div class="onboardingContent">
+            <p id="onboardingBody" class="onboardingBody">A community-built workshop for characters and motion.</p>
+
+            <!-- Wallet/ENS input -->
+            <div class="onboardingInputGroup">
+              <label class="fieldLabel" for="onboardingInput">Paste a wallet/ENS or token ID to begin</label>
+              <input
+                id="onboardingInput"
+                class="searchInput onboardingSearchInput"
+                type="text"
+                placeholder="Try pizzalord.eth or 8448"
+                autocomplete="off"
+                inputmode="search"
+              />
+              <div class="onboardingTrustPill" aria-hidden="true">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" stroke="currentColor" stroke-width="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                Read-only &bull; No wallet connect
+              </div>
+            </div>
+
+            <!-- Action tiles -->
+            <div class="onboardingTiles" role="list">
+              <div class="onboardingTile" role="listitem">
+                <svg class="tileIcon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <circle cx="12" cy="8" r="4" stroke="currentColor" stroke-width="2"/>
+                  <path d="M4 20c0-4 4-6 8-6s8 2 8 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                <div class="tileText">
+                  <strong>Load a character</strong>
+                  <span>Wallet, ENS, or Token ID</span>
+                </div>
+              </div>
+              <div class="onboardingTile" role="listitem">
+                <svg class="tileIcon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <polygon points="9,6 9,18 19,12" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+                </svg>
+                <div class="tileText">
+                  <strong>Preview animations</strong>
+                  <span>Swipe the carousel or select a clip</span>
+                </div>
+              </div>
+              <div class="onboardingTile" role="listitem">
+                <svg class="tileIcon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M12 3v12M12 15l-4-4M12 15l4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M4 19h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                <div class="tileText">
+                  <strong>Export rig-ready .glb</strong>
+                  <span>Clean export for games and tools</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Trust line -->
+            <p class="onboardingTrustLine">No wallet connect. We don't move anything. Ever.</p>
+          </div>
+
+          <!-- Actions -->
+          <div class="onboardingActions">
+            <button id="onboardingEnter" class="onboardingBtn onboardingBtn--primary" type="button">Enter Studio</button>
+            <button id="onboardingDemo" class="onboardingBtn onboardingBtn--secondary" type="button">Try a Demo</button>
+            <button id="onboardingSkip" class="onboardingBtn onboardingBtn--tertiary" type="button">Skip for now</button>
+          </div>
+
+          <!-- Pro tip -->
+          <p class="onboardingProTip">Pro tip: Share a collector link: <code>/pizzalord.eth</code></p>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -90,6 +90,10 @@ canvas {
   --text-muted: rgba(22, 26, 40, 0.35);
   --card-width: 120px;
   --card-gap: 14px;
+  --radius-xl: 28px;
+  --glass-shadow-wide: 0 16px 64px rgba(14, 20, 42, 0.12), 0 2px 12px rgba(14, 20, 42, 0.06);
+  --spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Carousel region (wrapper for toggle + carousel) */
@@ -652,6 +656,7 @@ canvas {
   margin-bottom: 10px;
 }
 
+/* ── Welcome modal ─────────────────────────────── */
 .onboarding {
   position: fixed;
   inset: 0;
@@ -659,63 +664,294 @@ canvas {
   background: rgba(9, 12, 18, 0.38);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
   padding: 16px;
   pointer-events: auto;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 300ms ease, visibility 0s linear 300ms;
 }
 
 .onboarding.is-open {
-  display: flex;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 300ms ease, visibility 0s linear 0s;
 }
 
+/* Card — glass with gradient border + grain */
 .onboardingCard {
-  width: min(420px, 100%);
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.86);
+  position: relative;
+  width: min(460px, 100%);
+  border-radius: var(--radius-xl);
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(16px) saturate(1.3);
+  -webkit-backdrop-filter: blur(16px) saturate(1.3);
   color: var(--text-primary);
-  box-shadow: var(--glass-shadow-elevated);
-  padding: 16px;
+  box-shadow: var(--glass-shadow-wide);
+  overflow: hidden;
+  border: 1px solid transparent;
+  background-clip: padding-box;
+  transform: translateY(24px) scale(0.96);
+  transition: transform 400ms var(--spring), opacity 300ms ease;
 }
 
-.onboardingCard h2 {
-  margin: 0 0 6px;
-  font-size: 18px;
+/* Gradient border ring */
+.onboardingCard::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    rgba(200, 180, 240, 0.4) 0%,
+    rgba(255, 190, 170, 0.3) 50%,
+    rgba(180, 220, 255, 0.35) 100%
+  );
+  z-index: -1;
 }
 
-.onboardingLead {
-  margin: 0 0 8px;
-  font-weight: 700;
-  font-size: 13px;
+/* Subtle grain noise overlay */
+.onboardingCard::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-size: 128px 128px;
+  pointer-events: none;
+  z-index: 1;
 }
 
-.onboardingCopy {
-  margin: 0 0 10px;
-  font-size: 12px;
-  line-height: 1.4;
-  color: var(--text-secondary);
+.onboarding.is-open .onboardingCard {
+  transform: translateY(0) scale(1);
 }
 
-.onboardingSteps {
+/* Header band */
+.onboardingHeader {
+  padding: 28px 28px 20px;
+  background: linear-gradient(
+    135deg,
+    rgba(200, 180, 240, 0.12) 0%,
+    rgba(255, 190, 170, 0.10) 100%
+  );
+  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  position: relative;
+  z-index: 2;
+}
+
+.onboardingTitle {
+  margin: 0 0 4px;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.onboardingSubtitle {
   margin: 0;
-  padding-left: 18px;
   font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-secondary);
-  display: grid;
-  gap: 4px;
 }
 
-.onboardingFinePrint {
-  margin: 10px 0;
+/* Content area */
+.onboardingContent {
+  padding: 20px 28px 0;
+  position: relative;
+  z-index: 2;
+}
+
+.onboardingBody {
+  margin: 0 0 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+/* Input group */
+.onboardingInputGroup {
+  margin-bottom: 16px;
+}
+
+.onboardingInputGroup .fieldLabel {
+  margin-bottom: 6px;
+}
+
+.onboardingSearchInput {
+  font-size: 15px;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(22, 26, 40, 0.08);
+  box-sizing: border-box;
+}
+
+.onboardingSearchInput:focus {
+  border-color: rgba(22, 26, 40, 0.18);
+  box-shadow: 0 0 0 3px rgba(200, 180, 240, 0.15);
+}
+
+.onboardingTrustPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  background: rgba(22, 26, 40, 0.04);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.onboardingTrustPill svg {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+/* Action tiles */
+.onboardingTiles {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.onboardingTile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  transition: background 150ms ease, transform 150ms var(--spring);
+}
+
+.onboardingTile:hover {
+  background: rgba(255, 255, 255, 0.8);
+  transform: scale(1.01);
+}
+
+.tileIcon {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  color: var(--text-secondary);
+}
+
+.tileText {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tileText strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.tileText span {
   font-size: 11px;
   color: var(--text-muted);
 }
 
+/* Trust line */
+.onboardingTrustLine {
+  margin: 0 0 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* Buttons */
 .onboardingActions {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
+  padding: 16px 28px 20px;
+  position: relative;
+  z-index: 2;
+}
+
+.onboardingBtn {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  transition: background 150ms ease, transform 150ms var(--spring), box-shadow 150ms ease;
+}
+
+.onboardingBtn:hover {
+  transform: scale(1.015);
+}
+
+.onboardingBtn:active {
+  transform: scale(0.98);
+}
+
+.onboardingBtn--primary {
+  background: rgba(22, 26, 40, 0.88);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(22, 26, 40, 0.18);
+}
+
+.onboardingBtn--primary:hover {
+  background: rgba(22, 26, 40, 0.95);
+  box-shadow: 0 6px 20px rgba(22, 26, 40, 0.22);
+}
+
+.onboardingBtn--secondary {
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--text-primary);
+  border: 1px solid rgba(22, 26, 40, 0.08);
+}
+
+.onboardingBtn--secondary:hover {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.onboardingBtn--tertiary {
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 500;
+  font-size: 13px;
+  padding: 8px 16px;
+}
+
+.onboardingBtn--tertiary:hover {
+  color: var(--text-primary);
+  background: rgba(22, 26, 40, 0.03);
+}
+
+/* Pro tip */
+.onboardingProTip {
+  padding: 0 28px 20px;
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+  position: relative;
+  z-index: 2;
+}
+
+.onboardingProTip code {
+  background: rgba(22, 26, 40, 0.06);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
 }
 
 .searchResults {
@@ -772,6 +1008,42 @@ canvas {
   .sheet.is-open {
     transform: translateY(0);
   }
+
+  /* Welcome modal → bottom sheet on mobile */
+  .onboarding {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .onboardingCard {
+    width: 100%;
+    max-height: 92dvh;
+    overflow-y: auto;
+    border-radius: 24px 24px 0 0;
+    transform: translateY(100%);
+    transition: transform 400ms var(--ease-out-expo);
+  }
+
+  .onboarding.is-open .onboardingCard {
+    transform: translateY(0);
+  }
+
+  .onboardingHeader {
+    padding: 24px 20px 16px;
+  }
+
+  .onboardingContent {
+    padding: 16px 20px 0;
+  }
+
+  .onboardingActions {
+    padding: 12px 20px 16px;
+  }
+
+  .onboardingProTip {
+    padding: 0 20px 20px;
+    padding-bottom: calc(20px + env(safe-area-inset-bottom));
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -786,5 +1058,13 @@ canvas {
   .glassCarousel {
     backdrop-filter: none;
     background: rgba(255, 255, 255, 0.85);
+  }
+
+  .onboardingCard,
+  .onboarding,
+  .onboardingTile,
+  .onboardingBtn {
+    transition: none !important;
+    transform: none !important;
   }
 }


### PR DESCRIPTION
- Replaced flat modal with glass card featuring gradient border ring,
  grain noise overlay, and upgraded typography hierarchy
- Added wallet/ENS input directly in the modal with trust pill
  ("Read-only • No wallet connect") so users can begin immediately
- Replaced numbered quickstart list with 3 visual action tiles
  (Load character, Preview animations, Export .glb)
- Three-tier CTAs: "Enter Studio" (submits input), "Try a Demo"
  (loads pizzalord.eth), "Skip for now" (dismiss)
- Mobile: modal becomes iOS-style bottom sheet (slides up from bottom)
- Added entry/exit animations (spring scale on desktop, slide-up on mobile)
- Focus trap + Escape key dismissal for accessibility
- Bumped localStorage key to v2 so returning users see the new modal
- Respects prefers-reduced-motion

https://claude.ai/code/session_01J1P8P1oD5xH2Q9CaHyJAoN