### PR TITLE
Stage 1-2: gear control surface (tabs) + console viewer modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       name="description"
       content="Community-built studio for viewing, previewing animations, and exporting rig-ready .glb assets."
     />
-    <link rel="stylesheet" href="/style.css?v=2026-02-12a" />
+    <link rel="stylesheet" href="/style.css?v=2026-02-13a" />
   </head>
 
   <body>
@@ -30,6 +30,50 @@
             <ul class="tokenTrack" id="tokenSlides"></ul>
             <div id="spacerRight" class="carouselSpacer"></div>
           </div>
+        </div>
+      </div>
+
+      <button id="controlGear" class="controlGear" type="button" aria-label="Open controls" aria-expanded="false">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none" />
+          <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1 1 0 0 1 0 1.4l-1.3 1.3a1 1 0 0 1-1.4 0l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1 1 0 0 1-1 1h-1.8a1 1 0 0 1-1-1v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1 1 0 0 1-1.4 0L4.9 17.9a1 1 0 0 1 0-1.4l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1 1 0 0 1-1-1v-1.8a1 1 0 0 1 1-1h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1 1 0 0 1 0-1.4L6.1 4.9a1 1 0 0 1 1.4 0l.1.1a1 1 0 0 0 1.1.2h.1a1 1 0 0 0 .6-.9V4a1 1 0 0 1 1-1h1.8a1 1 0 0 1 1 1v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1 1 0 0 1 1.4 0l1.3 1.3a1 1 0 0 1 0 1.4l-.1.1a1 1 0 0 0-.2 1.1v.1a1 1 0 0 0 .9.6H20a1 1 0 0 1 1 1v1.8a1 1 0 0 1-1 1h-.2a1 1 0 0 0-.9.6z" stroke="currentColor" stroke-width="1.5" fill="none" />
+        </svg>
+      </button>
+
+      <aside id="controlPanel" class="controlPanel" aria-hidden="true">
+        <div class="controlTabs">
+          <button class="controlTab is-active" type="button" data-control-tab="animations">Animations</button>
+          <button class="controlTab" type="button" data-control-tab="lighting">Lighting/Scene</button>
+          <button class="controlTab" type="button" data-control-tab="console">Console</button>
+        </div>
+        <div class="controlBody">
+          <section class="controlSection is-active" data-control-section="animations">
+            <label class="fieldLabel" for="controlAnimSelect">Animation</label>
+            <select id="controlAnimSelect" class="searchInput"></select>
+            <button id="controlPlayAnimBtn" class="sheetAction" type="button">Play selected animation</button>
+          </section>
+          <section class="controlSection" data-control-section="lighting">
+            <button class="sheetAction" data-control-preset="Cinematic" type="button">Cinematic</button>
+            <button class="sheetAction" data-control-preset="Punchy Studio" type="button">Punchy Studio</button>
+            <button class="sheetAction" data-control-preset="Soft Pastel" type="button">Soft Pastel</button>
+          </section>
+          <section class="controlSection" data-control-section="console">
+            <button id="openConsoleModal" class="sheetAction" type="button">Open console viewer</button>
+          </section>
+        </div>
+      </aside>
+
+      <div id="consoleModal" class="consoleModal" aria-hidden="true">
+        <div class="consoleCard" role="dialog" aria-modal="true" aria-label="Console viewer">
+          <div class="consoleHeader">
+            <strong>Console Viewer</strong>
+            <div class="consoleActions">
+              <button id="copyConsoleBtn" class="sheetAction" type="button">Copy</button>
+              <button id="clearConsoleBtn" class="sheetAction" type="button">Clear</button>
+              <button id="closeConsoleBtn" class="sheetAction" type="button">Close</button>
+            </div>
+          </div>
+          <pre id="consoleViewer" class="consoleViewer"></pre>
         </div>
       </div>
 
@@ -280,6 +324,6 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/EXRLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/exporters/GLTFExporter.js"></script>
-    <script src="/main.js?v=2026-02-12a"></script>
+    <script src="/main.js?v=2026-02-13a"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -477,20 +477,32 @@ function setControlPanelOpen(open) {
 function syncControlAnchor() {
   if (!controlGear || !ui.carouselRegion) return;
   const rect = ui.carouselRegion.getBoundingClientRect();
-  const rightGap = Math.max(10, window.innerWidth - rect.right + 8);
   const bottomGap = Math.max(12, window.innerHeight - rect.bottom + 12);
 
-  controlGear.style.right = `${rightGap}px`;
+  if (window.innerWidth <= 780) {
+    controlGear.style.left = "";
+    controlGear.style.right = "12px";
+    controlGear.style.bottom = `${bottomGap}px`;
+    if (controlPanel) {
+      controlPanel.style.left = "";
+      controlPanel.style.right = "";
+      controlPanel.style.bottom = "";
+    }
+    return;
+  }
+
+  const gearLeft = Math.min(window.innerWidth - 54, rect.right + 10);
+  controlGear.style.left = `${gearLeft}px`;
+  controlGear.style.right = "auto";
   controlGear.style.bottom = `${bottomGap}px`;
 
   if (!controlPanel) return;
-  if (window.innerWidth <= 780) {
-    controlPanel.style.right = "";
-    controlPanel.style.bottom = "";
-    return;
-  }
-  controlPanel.style.right = `${rightGap + 50}px`;
-  controlPanel.style.bottom = `${bottomGap - 8}px`;
+  const panelWidth = Math.min(360, window.innerWidth - 96);
+  const preferredLeft = gearLeft + 50;
+  const maxLeft = window.innerWidth - panelWidth - 12;
+  controlPanel.style.left = `${Math.min(preferredLeft, maxLeft)}px`;
+  controlPanel.style.right = "auto";
+  controlPanel.style.bottom = `${Math.max(20, bottomGap - 6)}px`;
 }
 
 function syncControlVisibility() {

--- a/style.css
+++ b/style.css
@@ -1068,6 +1068,12 @@ canvas {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+.controlGear.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.8) translateY(6px);
 }
 .controlGear svg { width: 20px; height: 20px; }
 .controlPanel {

--- a/style.css
+++ b/style.css
@@ -1110,9 +1110,11 @@ canvas {
   align-items: center;
   justify-content: center;
   background: rgba(11, 15, 22, 0.45);
+  pointer-events: auto;
 }
 .consoleModal.is-open { display: flex; }
 .consoleCard {
+  pointer-events: auto;
   width: min(860px, calc(100vw - 32px));
   height: min(70vh, 560px);
   background: rgba(18, 22, 28, 0.95);

--- a/style.css
+++ b/style.css
@@ -1056,32 +1056,37 @@ canvas {
   position: fixed;
   right: 16px;
   bottom: 132px;
-  z-index: 14;
-  width: 42px;
-  height: 42px;
+  z-index: 16;
+  width: 38px;
+  height: 38px;
   border-radius: 999px;
-  border: 1px solid var(--glass-border);
-  background: var(--glass-surface);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.44);
   color: var(--text-primary);
-  backdrop-filter: blur(var(--blur-sm));
-  -webkit-backdrop-filter: blur(var(--blur-sm));
+  box-shadow: 0 4px 18px rgba(14, 20, 42, 0.12);
+  backdrop-filter: blur(14px) saturate(1.15);
+  -webkit-backdrop-filter: blur(14px) saturate(1.15);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: opacity 220ms ease, transform 220ms ease;
+  cursor: pointer;
+  pointer-events: auto;
+  transition: opacity 220ms ease, transform 220ms ease, background 180ms ease;
 }
 .controlGear.is-hidden {
   opacity: 0;
   pointer-events: none;
   transform: scale(0.8) translateY(6px);
 }
-.controlGear svg { width: 20px; height: 20px; }
+.controlGear:hover { background: rgba(255, 255, 255, 0.66); }
+.controlGear svg { width: 18px; height: 18px; }
 .controlPanel {
   position: fixed;
   right: 66px;
   bottom: 98px;
   width: min(360px, calc(100vw - 96px));
-  z-index: 14;
+  z-index: 16;
+  pointer-events: auto;
   border-radius: var(--radius-lg);
   border: 1px solid var(--glass-border);
   background: var(--glass-surface-strong);
@@ -1123,11 +1128,11 @@ canvas {
 .consoleViewer { margin: 0; padding: 10px; overflow: auto; font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; }
 
 @media (max-width: 780px) {
-  .controlGear { right: 12px; bottom: 118px; }
+  .controlGear { right: 12px; bottom: 118px; left: auto; }
   .controlPanel {
     right: 0;
-    left: 0;
-    bottom: 0;
+    left: 0 !important;
+    bottom: 0 !important;
     width: 100%;
     border-radius: 14px 14px 0 0;
     padding: 12px;

--- a/style.css
+++ b/style.css
@@ -1052,6 +1052,82 @@ canvas {
   }
 }
 
+.controlGear {
+  position: fixed;
+  right: 16px;
+  bottom: 132px;
+  z-index: 14;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-surface);
+  color: var(--text-primary);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.controlGear svg { width: 20px; height: 20px; }
+.controlPanel {
+  position: fixed;
+  right: 66px;
+  bottom: 98px;
+  width: min(360px, calc(100vw - 96px));
+  z-index: 14;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-surface-strong);
+  backdrop-filter: blur(var(--blur-md));
+  -webkit-backdrop-filter: blur(var(--blur-md));
+  box-shadow: var(--glass-shadow);
+  padding: 10px;
+  display: none;
+}
+.controlPanel.is-open { display: block; }
+.controlTabs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; margin-bottom: 8px; }
+.controlTab { border: 1px solid var(--glass-border); border-radius: 8px; background: rgba(255,255,255,.6); font-size: 11px; padding: 6px; }
+.controlTab.is-active { background: rgba(255,255,255,.9); font-weight: 600; }
+.controlSection { display: none; gap: 8px; }
+.controlSection.is-active { display: grid; }
+.consoleModal {
+  position: fixed;
+  inset: 0;
+  z-index: 24;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(11, 15, 22, 0.45);
+}
+.consoleModal.is-open { display: flex; }
+.consoleCard {
+  width: min(860px, calc(100vw - 32px));
+  height: min(70vh, 560px);
+  background: rgba(18, 22, 28, 0.95);
+  color: #d7deea;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 12px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+}
+.consoleHeader { display: flex; align-items: center; justify-content: space-between; padding: 10px; border-bottom: 1px solid rgba(255,255,255,.1); }
+.consoleActions { display: flex; gap: 6px; }
+.consoleViewer { margin: 0; padding: 10px; overflow: auto; font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; }
+
+@media (max-width: 780px) {
+  .controlGear { right: 12px; bottom: 118px; }
+  .controlPanel {
+    right: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    border-radius: 14px 14px 0 0;
+    padding: 12px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tokenSlide,
   .tokenCard,


### PR DESCRIPTION
## What this staged PR ships\n\n### Stage 1: discoverable control surface\n- Adds always-visible gear icon near carousel\n- Desktop: opens compact right-side control shelf\n- Mobile: opens bottom sheet\n- Tabs:\n  - Animations (picker + play)\n  - Lighting/Scene (look presets)\n  - Console (open viewer)\n\n### Stage 2: console viewer\n- Adds console modal with Copy / Clear / Close\n- Captures app logs from logLine()\n- Captures runtime window.error and unhandledrejection\n\n## Behavior notes\n- Animation picker now surfaces in control shelf (not buried in onboarding)\n- Picker options are loaded from animation manifest flow already wired in app\n- Keeps existing hamburger/find/share/info flows intact\n\n## Risk profile\n- UI surface addition, no core rendering pipeline rewrite\n- JS syntax checked with 
ode --check main.js\n