### PR TITLE
Add /fren/<token> deep-linking with dynamic SEO meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
       name="description"
       content="Community-built studio for viewing, previewing animations, and exporting rig-ready .glb assets."
     />
+    <meta property="og:title" content="fRiENEMiES Studio — View • Animate • Export" />
+    <meta property="og:description" content="Community-built studio for viewing, previewing animations, and exporting rig-ready .glb assets." />
+    <meta property="og:type" content="website" />
     <link rel="stylesheet" href="/style.css?v=2026-02-13a" />
   </head>
 
@@ -306,7 +309,7 @@
           </div>
 
           <!-- Pro tip -->
-          <p class="onboardingProTip">Pro tip: Share a collector link: <code>/pizzalord.eth</code></p>
+          <p class="onboardingProTip">Pro tip: Share a token link: <code>/fren/8448</code> or collector link: <code>/pizzalord.eth</code></p>
         </div>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -50,7 +50,37 @@ const FRIENDSIES_CHAIN = "eth";
 // Token defaults
 // ----------------------------
 const DEFAULT_TOKEN_ID = 5;
+const FREN_DEFAULT_TOKEN_ID = 7499;
+const SAUCE_PRESET_TOKEN_ID = 8521;
+const FREN_TOKEN_MIN = 1;
+const FREN_TOKEN_MAX = 10000;
 const DEFAULT_TOKEN_IDS = Array.from({ length: 10000 }, (_, i) => i + 1);
+let frenRouteActive = false;
+
+// ----------------------------
+// /fren/<token> route parsing (centralized)
+// ----------------------------
+function parseFrenTokenFromUrl(pathname) {
+  if (pathname == null) pathname = window.location.pathname;
+  const match = pathname.match(/^\/fren\/(\d+)\/?$/);
+  if (!match) return null;
+  const num = Number(match[1]);
+  if (!Number.isInteger(num) || num < FREN_TOKEN_MIN || num > FREN_TOKEN_MAX) return null;
+  return num;
+}
+
+function parseFrenTokenFromUrlRaw(pathname) {
+  // Returns the raw numeric value even if out of range, for error messaging.
+  if (pathname == null) pathname = window.location.pathname;
+  const match = pathname.match(/^\/fren\/(\d+)\/?$/);
+  if (!match) return null;
+  return Number(match[1]);
+}
+
+function isFrenRoute(pathname) {
+  if (pathname == null) pathname = window.location.pathname;
+  return /^\/fren\//.test(pathname);
+}
 
 function isHexAddress(value) {
   return typeof value === "string" && /^0x[0-9a-fA-F]{40}$/.test(value.trim());
@@ -2261,6 +2291,18 @@ async function loadFriendsies(id) {
 
 function loadToken(tokenId) {
   loadFriendsies(tokenId);
+
+  // Keep URL in sync when browsing tokens on a /fren/ route
+  if (frenRouteActive && tokenId != null) {
+    const id = Number(tokenId);
+    if (Number.isFinite(id) && id >= FREN_TOKEN_MIN && id <= FREN_TOKEN_MAX) {
+      const currentFren = parseFrenTokenFromUrl();
+      if (currentFren !== id) {
+        window.history.replaceState({ frenToken: id }, "", `/fren/${id}`);
+      }
+      updateFrenMeta(id);
+    }
+  }
 }
 
 // ----------------------------
@@ -2591,6 +2633,8 @@ function updateResetCollectionVisibility() {
 function resetToFullCollection() {
   setCarouselTokenIds(DEFAULT_TOKEN_IDS);
   initCarousel(DEFAULT_TOKEN_ID);
+  frenRouteActive = false;
+  updateFrenMeta(null);
   window.history.pushState({}, "", "/");
   logLine("🔄 Reset to full collection");
   updateResetCollectionVisibility();
@@ -2606,6 +2650,8 @@ async function navigateToWallet(owner) {
       }
       return;
     }
+    frenRouteActive = false;
+    updateFrenMeta(null);
     setCarouselTokenIds(walletData.tokenIds);
     initCarousel(walletData.tokenIds[0]);
     const slug = walletData.ownerInput || owner;
@@ -3408,13 +3454,175 @@ window.addEventListener("unhandledrejection", (event) => {
 
 
 // ----------------------------
+// Dynamic SEO / OG meta helpers
+// ----------------------------
+function updateFrenMeta(tokenId) {
+  if (tokenId != null) {
+    document.title = `fRiENEMiES #${tokenId}`;
+    setMetaTag("og:title", `fRiENEMiES #${tokenId}`);
+    setMetaTag("og:image", `https://storage.googleapis.com/friendsies-rendered-97557c/${tokenId}/friendsie.jpg`);
+    setMetaTag("og:url", `${window.location.origin}/fren/${tokenId}`);
+    setMetaTag("og:description", `View fRiENEMiES token #${tokenId} in the studio.`);
+    setMetaTag("og:type", "website");
+  } else {
+    document.title = "fRiENEMiES Studio \u2014 View \u2022 Animate \u2022 Export";
+    removeMetaTag("og:title");
+    removeMetaTag("og:image");
+    removeMetaTag("og:url");
+    removeMetaTag("og:description");
+    removeMetaTag("og:type");
+  }
+}
+
+function setMetaTag(property, content) {
+  let el = document.querySelector(`meta[property="${property}"]`);
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute("property", property);
+    document.head.appendChild(el);
+  }
+  el.setAttribute("content", content);
+}
+
+function removeMetaTag(property) {
+  const el = document.querySelector(`meta[property="${property}"]`);
+  if (el) el.remove();
+}
+
+// ----------------------------
+// /fren/ route navigation (client-side, no full reload)
+// ----------------------------
+function navigateToFrenToken(tokenId, { replace = false } = {}) {
+  const id = Number(tokenId);
+  if (!Number.isFinite(id) || id < FREN_TOKEN_MIN || id > FREN_TOKEN_MAX) {
+    logLine(`⚠️ Invalid fren token: ${tokenId}, falling back to #${FREN_DEFAULT_TOKEN_ID}`, "warn");
+    navigateToFrenToken(FREN_DEFAULT_TOKEN_ID, { replace: true });
+    return;
+  }
+
+  frenRouteActive = true;
+  const path = `/fren/${id}`;
+  if (replace) {
+    window.history.replaceState({ frenToken: id }, "", path);
+  } else {
+    window.history.pushState({ frenToken: id }, "", path);
+  }
+  updateFrenMeta(id);
+
+  // Ensure full collection carousel is available
+  if (carouselTokenIds.length < DEFAULT_TOKEN_IDS.length) {
+    setCarouselTokenIds(DEFAULT_TOKEN_IDS);
+    initCarousel(id);
+  }
+
+  // Scroll carousel to this token and load
+  const index = carouselTokenIds.indexOf(id);
+  if (index >= 0) {
+    scrollToCarouselIndex(index);
+    setActiveCarouselIndex(index, { forceLoad: true });
+  } else {
+    // Token in range but not in carousel (shouldn't happen with full collection)
+    lastLoadedTokenId = id;
+    loadToken(id);
+  }
+}
+
+function handleFrenTokenFromMetadata(frenTokenId) {
+  // Called after metadata loads when a /fren/ deep-link was detected.
+  // frenTokenId is already validated to be in [1..10000].
+  const entry = getEntryById(frenTokenId);
+  if (!entry) {
+    logLine(`⚠️ Token #${frenTokenId} not found in metadata, falling back to #${FREN_DEFAULT_TOKEN_ID}`, "warn");
+    setStatus(`token #${frenTokenId} not found`);
+    navigateToFrenToken(FREN_DEFAULT_TOKEN_ID, { replace: true });
+    return;
+  }
+  // Load the token via existing pipeline
+  const index = carouselTokenIds.indexOf(frenTokenId);
+  if (index >= 0) {
+    scrollToCarouselIndex(index);
+    setActiveCarouselIndex(index, { forceLoad: true });
+  } else {
+    lastLoadedTokenId = frenTokenId;
+    loadToken(frenTokenId);
+  }
+}
+
+// popstate: handle back/forward between /fren/ routes
+window.addEventListener("popstate", (event) => {
+  const pathname = window.location.pathname;
+
+  // Check if navigating to a /fren/ route
+  const frenToken = parseFrenTokenFromUrl(pathname);
+  if (frenToken != null) {
+    frenRouteActive = true;
+    updateFrenMeta(frenToken);
+    if (allFriendsies) {
+      handleFrenTokenFromMetadata(frenToken);
+    } else {
+      pendingTokenId = frenToken;
+    }
+    return;
+  }
+
+  // Check for raw out-of-range fren route
+  if (isFrenRoute(pathname)) {
+    frenRouteActive = true;
+    const raw = parseFrenTokenFromUrlRaw(pathname);
+    logLine(`⚠️ Invalid fren token: ${raw}, falling back to #${FREN_DEFAULT_TOKEN_ID}`, "warn");
+    navigateToFrenToken(FREN_DEFAULT_TOKEN_ID, { replace: true });
+    return;
+  }
+
+  // Non-fren route (e.g. back to /)
+  frenRouteActive = false;
+  updateFrenMeta(null);
+
+  // Check for wallet/ENS owner
+  const owner = getWalletOwnerFromUrl();
+  if (owner) {
+    navigateToWallet(owner);
+    return;
+  }
+
+  // Default: show full collection
+  setCarouselTokenIds(DEFAULT_TOKEN_IDS);
+  initCarousel(DEFAULT_TOKEN_ID);
+});
+
+// ----------------------------
 // Boot sequence
 // ----------------------------
 (async function boot() {
-  const ownerFromUrl = getWalletOwnerFromUrl();
+  const frenTokenValid = parseFrenTokenFromUrl();
+  const frenTokenRaw = parseFrenTokenFromUrlRaw();
+  const ownerFromUrl = !isFrenRoute() ? getWalletOwnerFromUrl() : null;
   let carouselStartTokenId = DEFAULT_TOKEN_ID;
 
-  if (ownerFromUrl) {
+  if (frenTokenValid != null) {
+    // /fren/<valid_token> deep-link
+    frenRouteActive = true;
+    carouselStartTokenId = frenTokenValid;
+    updateFrenMeta(frenTokenValid);
+    setCarouselTokenIds(DEFAULT_TOKEN_IDS);
+    logLine(`🔗 Fren deep-link: #${frenTokenValid}`, "dim");
+  } else if (isFrenRoute() && frenTokenRaw != null) {
+    // /fren/<invalid_token> (out of range)
+    frenRouteActive = true;
+    logLine(`⚠️ Invalid fren token: ${frenTokenRaw}, falling back to #${FREN_DEFAULT_TOKEN_ID}`, "warn");
+    carouselStartTokenId = FREN_DEFAULT_TOKEN_ID;
+    updateFrenMeta(FREN_DEFAULT_TOKEN_ID);
+    window.history.replaceState({ frenToken: FREN_DEFAULT_TOKEN_ID }, "", `/fren/${FREN_DEFAULT_TOKEN_ID}`);
+    setCarouselTokenIds(DEFAULT_TOKEN_IDS);
+  } else if (isFrenRoute()) {
+    // /fren/ with non-numeric or missing token
+    frenRouteActive = true;
+    logLine(`⚠️ Invalid fren route, falling back to #${FREN_DEFAULT_TOKEN_ID}`, "warn");
+    carouselStartTokenId = FREN_DEFAULT_TOKEN_ID;
+    updateFrenMeta(FREN_DEFAULT_TOKEN_ID);
+    window.history.replaceState({ frenToken: FREN_DEFAULT_TOKEN_ID }, "", `/fren/${FREN_DEFAULT_TOKEN_ID}`);
+    setCarouselTokenIds(DEFAULT_TOKEN_IDS);
+  } else if (ownerFromUrl) {
     setStatus("fetching wallet tokens…");
     try {
       const walletData = await fetchWalletTokenIds(ownerFromUrl);
@@ -3447,7 +3655,12 @@ window.addEventListener("unhandledrejection", (event) => {
   syncControlVisibility();
   showHamburger();
   scheduleIdleTimer();
-  showOnboarding(false);
+  // Skip onboarding when landing on a /fren/ deep-link
+  if (!frenRouteActive) {
+    showOnboarding(false);
+  } else {
+    hideOnboarding(true);
+  }
 
   validateLookConfig(LOOK_CONTROLS, "LOOK_CONTROLS");
   validateLookConfig(
@@ -3469,7 +3682,14 @@ window.addEventListener("unhandledrejection", (event) => {
     .then((data) => {
       allFriendsies = data;
       setStatus("ready ✅");
-      if (pendingTokenId) {
+
+      if (frenRouteActive && frenTokenValid) {
+        // /fren/ deep-link: validate token exists in metadata and load
+        handleFrenTokenFromMetadata(frenTokenValid);
+      } else if (frenRouteActive) {
+        // Invalid fren route already fell back to FREN_DEFAULT_TOKEN_ID
+        handleFrenTokenFromMetadata(FREN_DEFAULT_TOKEN_ID);
+      } else if (pendingTokenId) {
         debounceTokenLoad(pendingTokenId);
       } else {
         // Load whatever token the carousel was initialized to (wallet deep-link uses first owned).

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "rewrites": [
     {
+      "source": "/fren/:token",
+      "destination": "/index.html"
+    },
+    {
       "source": "/:owner(0x[0-9a-fA-F]{40}|[^/]+\\.eth)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
This PR adds support for shareable deep-links to individual tokens via `/fren/<token>` routes, complete with dynamic Open Graph meta tags for social media previews. Users can now share direct links to specific tokens (e.g., `/fren/8448`) that load the token in the carousel and display rich preview metadata when shared.

## Key Changes

- **Route parsing utilities**: Added `parseFrenTokenFromUrl()`, `parseFrenTokenFromUrlRaw()`, and `isFrenRoute()` helper functions to centralize `/fren/` route detection and validation (tokens must be in range 1–10000)

- **Dynamic SEO/OG meta tags**: Implemented `updateFrenMeta()`, `setMetaTag()`, and `removeMetaTag()` functions to dynamically update page title and Open Graph metadata (og:title, og:image, og:url, og:description) based on the active token

- **Client-side navigation**: Added `navigateToFrenToken()` function to handle navigation to a specific token without full page reload, with fallback to default token (#7499) for invalid IDs

- **History API integration**: Added `popstate` event listener to handle browser back/forward navigation between `/fren/` routes and other views (wallet, full collection)

- **Boot sequence updates**: Enhanced initialization to detect and handle `/fren/` deep-links, including validation against metadata and graceful fallback for out-of-range tokens

- **URL sync during browsing**: Modified `loadToken()` to keep the URL in sync when browsing tokens while on a `/fren/` route

- **Vercel rewrites**: Added rewrite rule in `vercel.json` to route `/fren/:token` to `index.html` for client-side handling

- **UI updates**: Updated onboarding text to showcase the new `/fren/<token>` sharing format and added default OG meta tags to `index.html`

## Implementation Details

- Token IDs are validated to be integers in the range [1, 10000] before navigation
- Invalid tokens (out of range or malformed) automatically fall back to `FREN_DEFAULT_TOKEN_ID` (7499)
- The `frenRouteActive` flag tracks whether the user is currently on a `/fren/` route to coordinate URL updates and metadata
- Onboarding is skipped when landing on a `/fren/` deep-link to provide a cleaner experience
- Metadata validation ensures tokens exist before loading; missing tokens trigger a fallback with user feedback

https://claude.ai/code/session_01KE7G9aCC9LELuwobJX581L