### PR TITLE
Prevent default drag behavior on carousel to improve gesture handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -3770,6 +3770,9 @@ function onDragStart(e) {
   const vp = ui.carouselViewport;
   if (!vp) return;
 
+  // Prevent browser default drag/selection so the gesture stays with our handler
+  e.preventDefault();
+
   stopMomentum();
   isDragging = setDragPhysicsField("isDragging", false); // hasn't moved past threshold yet
   dragStartX = setDragPhysicsField("dragStartX", e.clientX);
@@ -3796,6 +3799,9 @@ function onDragMove(e) {
   }
 
   if (!isDragging) return;
+
+  // Suppress any residual browser handling once committed to drag
+  e.preventDefault();
 
   // Track velocity from recent movement
   const now = performance.now();
@@ -3875,6 +3881,9 @@ function bindCarouselListeners() {
     if (Number.isNaN(index)) return;
     scrollToCarouselIndex(index);
   });
+
+  // Block native drag-and-drop on the carousel so pointer-drag owns the gesture
+  ui.carouselViewport.addEventListener("dragstart", (e) => e.preventDefault());
 
   // Pointer-drag with momentum (desktop fling scrolling)
   ui.carouselViewport.addEventListener("pointerdown", (e) => {

--- a/style.css
+++ b/style.css
@@ -459,6 +459,8 @@ canvas {
   transform: translateZ(0);
   -webkit-overflow-scrolling: touch;
   cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
   /* Let browser handle touch natively (momentum for free on mobile).
      Pointer-drag momentum is JS-driven for mouse/pen only. */
   touch-action: pan-x pan-y;


### PR DESCRIPTION
## Summary
This PR improves the carousel's pointer-drag gesture handling by preventing browser default drag and selection behaviors, ensuring the custom drag handler maintains full control of the interaction.

## Key Changes
- **JavaScript (`main.js`)**:
  - Added `e.preventDefault()` in `onDragStart()` to prevent browser default drag/selection when drag begins
  - Added `e.preventDefault()` in `onDragMove()` to suppress residual browser handling during active drag
  - Added a `dragstart` event listener on the carousel viewport that prevents native drag-and-drop, ensuring pointer-drag gestures take precedence

- **CSS (`style.css`)**:
  - Added `user-select: none` and `-webkit-user-select: none` to the carousel viewport to prevent text selection during drag interactions

## Implementation Details
These changes work together to create a seamless custom drag experience:
1. The CSS prevents accidental text selection while dragging
2. The `dragstart` listener blocks native drag-and-drop functionality
3. The `preventDefault()` calls in the drag handlers ensure the browser doesn't interfere with momentum physics calculations or gesture tracking

This approach maintains compatibility with native touch scrolling on mobile (via `touch-action: pan-x pan-y`) while giving the custom pointer-drag handler exclusive control on desktop.

https://claude.ai/code/session_016BiqWmK6Fr33QCdiJyr5jV